### PR TITLE
Adds the OWNERS and OWNERS_ALIASES files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - core-ack-team
+  - service-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
+
+aliases:
+  # Always allow the core ACK maintainers to have access to your repository
+  core-ack-team:
+    - jaypipes
+    - mhausenblas
+    - a-hilaly
+    - RedbackThomson
+    - vijtrip2
+  # TODO: Add your team members to your team controller alias
+  service-team: []


### PR DESCRIPTION
Issue aws-controllers-k8s/community#778

Adds the OWNERS and OWNERS_ALIASES files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.