### PR TITLE
Regenerates the DynamoDB controller with `ack-generate` v0.2.3

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,0 +1,14 @@
+ack_generate_info:
+  build_date: "2021-06-21T19:55:19Z"
+  build_hash: d5797469ebb582083970136fc08f5de973e9ff1a
+  go_version: go1.16.4 linux/amd64
+  version: v0.2.3
+api_directory_checksum: 165a8edaf7a95b18c593e1d194033807a48af063
+api_version: v1alpha1
+aws_sdk_go_version: ""
+generator_config_info:
+  file_checksum: d5c4e7713b1f255a7eca67a8c829344452bb49d4
+  original_file_name: generator.yaml
+last_modification:
+  reason: API generation
+  timestamp: 2021-06-21 19:55:21.017906769 +0000 UTC

--- a/apis/v1alpha1/backup.go
+++ b/apis/v1alpha1/backup.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BackupSpec defines the desired state of Backup
+// BackupSpec defines the desired state of Backup.
 type BackupSpec struct {
 	// Specified name for the backup.
 	// +kubebuilder:validation:Required

--- a/apis/v1alpha1/global_table.go
+++ b/apis/v1alpha1/global_table.go
@@ -20,7 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GlobalTableSpec defines the desired state of GlobalTable
+// GlobalTableSpec defines the desired state of GlobalTable.
+//
+// Represents the properties of a global table.
 type GlobalTableSpec struct {
 	// The global table name.
 	// +kubebuilder:validation:Required

--- a/apis/v1alpha1/table.go
+++ b/apis/v1alpha1/table.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TableSpec defines the desired state of Table
+// TableSpec defines the desired state of Table.
 type TableSpec struct {
 	// An array of attributes that describe the key schema for the table and indexes.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupSpec defines the desired state of Backup
+            description: BackupSpec defines the desired state of Backup.
             properties:
               backupName:
                 description: Specified name for the backup.

--- a/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
@@ -34,7 +34,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: GlobalTableSpec defines the desired state of GlobalTable
+            description: "GlobalTableSpec defines the desired state of GlobalTable.
+              \n Represents the properties of a global table."
             properties:
               globalTableName:
                 description: The global table name.

--- a/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TableSpec defines the desired state of Table
+            description: TableSpec defines the desired state of Table.
             properties:
               attributeDefinitions:
                 description: An array of attributes that describe the key schema for

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/dynamodb-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.2.1
+	github.com/aws-controllers-k8s/runtime v0.2.3
 	github.com/aws/aws-sdk-go v1.38.47
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.2.1 h1:vItjQ5/pZjr8Z7cR35sQKcSjQy19mF3qOfbUitWMt1A=
-github.com/aws-controllers-k8s/runtime v0.2.1/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.2.3 h1:pDDSXOJj5QLlC9OcgnGujeocQEg5U1oqQw3kUSDefLU=
+github.com/aws-controllers-k8s/runtime v0.2.3/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.47 h1:yWOz6zlDCiY3zvebYOZrI1LqCq6zWPWC5Cfe+mBcPos=
 github.com/aws/aws-sdk-go v1.38.47/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/pkg/resource/backup/manager.go
+++ b/pkg/resource/backup/manager.go
@@ -18,16 +18,16 @@ package backup
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"

--- a/pkg/resource/backup/sdk.go
+++ b/pkg/resource/backup/sdk.go
@@ -22,12 +22,14 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Hack to avoid import errors during build...
@@ -39,13 +41,17 @@ var (
 	_ = &svcapitypes.Backup{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
 func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
-) (*resource, error) {
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkFind")
+	defer exit(err)
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -58,13 +64,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.DescribeBackupWithContext(ctx, input)
-	rm.metrics.RecordAPICall("READ_ONE", "DescribeBackup", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "BackupNotFoundException" {
+	var resp *svcsdkapi.DescribeBackupOutput
+	resp, err = rm.sdkapi.DescribeBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeBackup", err)
+	if err != nil {
+		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "BackupNotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, respErr
+		return nil, err
 	}
 
 	// Merge in the information we read from the API call above to the copy of
@@ -110,7 +117,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	if isBackupCreating(&resource{ko}) {
 		return &resource{ko}, requeueWaitWhileCreating
 	}
@@ -144,24 +150,29 @@ func (rm *resourceManager) newDescribeRequestPayload(
 }
 
 // sdkCreate creates the supplied resource in the backend AWS service API and
-// returns a new resource with any fields in the Status field filled in
+// returns a copy of the resource with resource fields (in both Spec and
+// Status) filled in with values from the CREATE API operation's Output shape.
 func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
-	r *resource,
-) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(ctx, r)
+	desired *resource,
+) (created *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkCreate")
+	defer exit(err)
+	input, err := rm.newCreateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.CreateBackupWithContext(ctx, input)
-	rm.metrics.RecordAPICall("CREATE", "CreateBackup", respErr)
-	if respErr != nil {
-		return nil, respErr
+	var resp *svcsdkapi.CreateBackupOutput
+	resp, err = rm.sdkapi.CreateBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateBackup", err)
+	if err != nil {
+		return nil, err
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -197,7 +208,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -235,15 +245,17 @@ func (rm *resourceManager) sdkUpdate(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) error {
-
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkDelete")
+	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return err
 	}
-	_, respErr := rm.sdkapi.DeleteBackupWithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "DeleteBackup", respErr)
-	return respErr
+	_, err = rm.sdkapi.DeleteBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteBackup", err)
+	return err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/global_table/manager.go
+++ b/pkg/resource/global_table/manager.go
@@ -18,16 +18,16 @@ package global_table
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"

--- a/pkg/resource/global_table/sdk.go
+++ b/pkg/resource/global_table/sdk.go
@@ -22,12 +22,14 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Hack to avoid import errors during build...
@@ -39,13 +41,17 @@ var (
 	_ = &svcapitypes.GlobalTable{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
 func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
-) (*resource, error) {
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkFind")
+	defer exit(err)
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -58,13 +64,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.DescribeGlobalTableWithContext(ctx, input)
-	rm.metrics.RecordAPICall("READ_ONE", "DescribeGlobalTable", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "GlobalTableNotFoundException" {
+	var resp *svcsdkapi.DescribeGlobalTableOutput
+	resp, err = rm.sdkapi.DescribeGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeGlobalTable", err)
+	if err != nil {
+		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "GlobalTableNotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, respErr
+		return nil, err
 	}
 
 	// Merge in the information we read from the API call above to the copy of
@@ -108,7 +115,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -137,24 +143,29 @@ func (rm *resourceManager) newDescribeRequestPayload(
 }
 
 // sdkCreate creates the supplied resource in the backend AWS service API and
-// returns a new resource with any fields in the Status field filled in
+// returns a copy of the resource with resource fields (in both Spec and
+// Status) filled in with values from the CREATE API operation's Output shape.
 func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
-	r *resource,
-) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(ctx, r)
+	desired *resource,
+) (created *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkCreate")
+	defer exit(err)
+	input, err := rm.newCreateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.CreateGlobalTableWithContext(ctx, input)
-	rm.metrics.RecordAPICall("CREATE", "CreateGlobalTable", respErr)
-	if respErr != nil {
-		return nil, respErr
+	var resp *svcsdkapi.CreateGlobalTableOutput
+	resp, err = rm.sdkapi.CreateGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateGlobalTable", err)
+	if err != nil {
+		return nil, err
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.GlobalTableDescription.CreationDateTime != nil {
 		ko.Status.CreationDateTime = &metav1.Time{*resp.GlobalTableDescription.CreationDateTime}
@@ -175,7 +186,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -221,16 +231,18 @@ func (rm *resourceManager) sdkUpdate(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) error {
-
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkDelete")
+	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return err
 	}
 	customSetDeleteInput(r, input)
-	_, respErr := rm.sdkapi.UpdateGlobalTableWithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "UpdateGlobalTable", respErr)
-	return respErr
+	_, err = rm.sdkapi.UpdateGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "UpdateGlobalTable", err)
+	return err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/table/manager.go
+++ b/pkg/resource/table/manager.go
@@ -18,16 +18,16 @@ package table
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"


### PR DESCRIPTION
Regenerates the DynamoDB controller with `ack-generate` v0.2.3` to get to ACK runtime v0.2.3.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.