### PR TITLE
Bump runtime version and regenerates the controller with `ack-generate` v0.3.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-06-21T19:55:19Z"
-  build_hash: d5797469ebb582083970136fc08f5de973e9ff1a
+  build_date: "2021-06-24T15:42:29Z"
+  build_hash: 9c35918f8a98b41ada10cb3aa460dbf463428463
   go_version: go1.16.4 linux/amd64
   version: v0.2.3
 api_directory_checksum: 165a8edaf7a95b18c593e1d194033807a48af063
 api_version: v1alpha1
-aws_sdk_go_version: ""
+aws_sdk_go_version: v1.38.60
 generator_config_info:
   file_checksum: d5c4e7713b1f255a7eca67a8c829344452bb49d4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-06-21 19:55:21.017906769 +0000 UTC
+  timestamp: 2021-06-24 15:42:31.137979168 +0000 UTC

--- a/pkg/resource/backup/manager.go
+++ b/pkg/resource/backup/manager.go
@@ -197,7 +197,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -217,7 +217,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/pkg/resource/backup/manager_factory.go
+++ b/pkg/resource/backup/manager_factory.go
@@ -79,6 +79,12 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return true
 }
 
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success.
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
+	return 0
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/pkg/resource/backup/resource.go
+++ b/pkg/resource/backup/resource.go
@@ -74,6 +74,11 @@ func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
 
+// ReplaceConditions sets the Conditions status field for the resource
+func (r *resource) ReplaceConditions(conditions []*ackv1alpha1.Condition) {
+	r.ko.Status.Conditions = conditions
+}
+
 // SetObjectMeta sets the ObjectMeta field for the resource
 func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta

--- a/pkg/resource/backup/sdk.go
+++ b/pkg/resource/backup/sdk.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Hack to avoid import errors during build...
@@ -41,7 +40,6 @@ var (
 	_ = &svcapitypes.Backup{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
-	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -64,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.DescribeBackupOutput
+	var resp *svcsdk.DescribeBackupOutput
 	resp, err = rm.sdkapi.DescribeBackupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_ONE", "DescribeBackup", err)
 	if err != nil {
@@ -164,7 +162,8 @@ func (rm *resourceManager) sdkCreate(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.CreateBackupOutput
+	var resp *svcsdk.CreateBackupOutput
+	_ = resp
 	resp, err = rm.sdkapi.CreateBackupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("CREATE", "CreateBackup", err)
 	if err != nil {
@@ -293,6 +292,7 @@ func (rm *resourceManager) setStatusDefaults(
 // else it returns nil, false
 func (rm *resourceManager) updateConditions(
 	r *resource,
+	onSuccess bool,
 	err error,
 ) (*resource, bool) {
 	ko := r.ko.DeepCopy()
@@ -301,12 +301,16 @@ func (rm *resourceManager) updateConditions(
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
 	var recoverableCondition *ackv1alpha1.Condition = nil
+	var syncCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
 		}
 		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
 			recoverableCondition = condition
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			syncCondition = condition
 		}
 	}
 
@@ -348,7 +352,9 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	if terminalCondition != nil || recoverableCondition != nil {
+	// Required to avoid the "declared but not used" error in the default case
+	_ = syncCondition
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/global_table/manager.go
+++ b/pkg/resource/global_table/manager.go
@@ -197,7 +197,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -217,7 +217,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/pkg/resource/global_table/manager_factory.go
+++ b/pkg/resource/global_table/manager_factory.go
@@ -79,6 +79,12 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return true
 }
 
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success.
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
+	return 0
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/pkg/resource/global_table/resource.go
+++ b/pkg/resource/global_table/resource.go
@@ -74,6 +74,11 @@ func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
 
+// ReplaceConditions sets the Conditions status field for the resource
+func (r *resource) ReplaceConditions(conditions []*ackv1alpha1.Condition) {
+	r.ko.Status.Conditions = conditions
+}
+
 // SetObjectMeta sets the ObjectMeta field for the resource
 func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta

--- a/pkg/resource/global_table/sdk.go
+++ b/pkg/resource/global_table/sdk.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Hack to avoid import errors during build...
@@ -41,7 +40,6 @@ var (
 	_ = &svcapitypes.GlobalTable{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
-	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -64,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.DescribeGlobalTableOutput
+	var resp *svcsdk.DescribeGlobalTableOutput
 	resp, err = rm.sdkapi.DescribeGlobalTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_ONE", "DescribeGlobalTable", err)
 	if err != nil {
@@ -157,7 +155,8 @@ func (rm *resourceManager) sdkCreate(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.CreateGlobalTableOutput
+	var resp *svcsdk.CreateGlobalTableOutput
+	_ = resp
 	resp, err = rm.sdkapi.CreateGlobalTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("CREATE", "CreateGlobalTable", err)
 	if err != nil {
@@ -278,6 +277,7 @@ func (rm *resourceManager) setStatusDefaults(
 // else it returns nil, false
 func (rm *resourceManager) updateConditions(
 	r *resource,
+	onSuccess bool,
 	err error,
 ) (*resource, bool) {
 	ko := r.ko.DeepCopy()
@@ -286,12 +286,16 @@ func (rm *resourceManager) updateConditions(
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
 	var recoverableCondition *ackv1alpha1.Condition = nil
+	var syncCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
 		}
 		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
 			recoverableCondition = condition
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			syncCondition = condition
 		}
 	}
 
@@ -333,7 +337,9 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	if terminalCondition != nil || recoverableCondition != nil {
+	// Required to avoid the "declared but not used" error in the default case
+	_ = syncCondition
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/table/manager.go
+++ b/pkg/resource/table/manager.go
@@ -197,7 +197,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -217,7 +217,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/pkg/resource/table/manager_factory.go
+++ b/pkg/resource/table/manager_factory.go
@@ -79,6 +79,12 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return true
 }
 
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success.
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
+	return 0
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/pkg/resource/table/resource.go
+++ b/pkg/resource/table/resource.go
@@ -74,6 +74,11 @@ func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
 
+// ReplaceConditions sets the Conditions status field for the resource
+func (r *resource) ReplaceConditions(conditions []*ackv1alpha1.Condition) {
+	r.ko.Status.Conditions = conditions
+}
+
 // SetObjectMeta sets the ObjectMeta field for the resource
 func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta

--- a/pkg/resource/table/sdk.go
+++ b/pkg/resource/table/sdk.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Hack to avoid import errors during build...
@@ -41,7 +40,6 @@ var (
 	_ = &svcapitypes.Table{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
-	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -64,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.DescribeTableOutput
+	var resp *svcsdk.DescribeTableOutput
 	resp, err = rm.sdkapi.DescribeTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_ONE", "DescribeTable", err)
 	if err != nil {
@@ -448,7 +446,8 @@ func (rm *resourceManager) sdkCreate(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.CreateTableOutput
+	var resp *svcsdk.CreateTableOutput
+	_ = resp
 	resp, err = rm.sdkapi.CreateTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("CREATE", "CreateTable", err)
 	if err != nil {
@@ -848,7 +847,8 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 
-	var resp *svcsdkapi.UpdateTableOutput
+	var resp *svcsdk.UpdateTableOutput
+	_ = resp
 	resp, err = rm.sdkapi.UpdateTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "UpdateTable", err)
 	if err != nil {
@@ -1147,6 +1147,7 @@ func (rm *resourceManager) setStatusDefaults(
 // else it returns nil, false
 func (rm *resourceManager) updateConditions(
 	r *resource,
+	onSuccess bool,
 	err error,
 ) (*resource, bool) {
 	ko := r.ko.DeepCopy()
@@ -1155,12 +1156,16 @@ func (rm *resourceManager) updateConditions(
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
 	var recoverableCondition *ackv1alpha1.Condition = nil
+	var syncCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
 		}
 		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
 			recoverableCondition = condition
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			syncCondition = condition
 		}
 	}
 
@@ -1202,7 +1207,9 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	if terminalCondition != nil || recoverableCondition != nil {
+	// Required to avoid the "declared but not used" error in the default case
+	_ = syncCondition
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated


### PR DESCRIPTION
Regenerates the DynamoDB controller with `ack-generate` v0.3.1 
to bring in runtime `v0.3.0` improvements and features.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.