### PR TITLE
Bump runtime version and regenerate controller with ack-generate v0.12.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-07-21T20:07:28Z"
-  build_hash: b1805be8f7a901c16ae6b451054dbdaf100285b2
-  go_version: go1.15.6 linux/amd64
-  version: v0.7.0
+  build_date: "2021-08-20T14:19:51Z"
+  build_hash: 821a0daf362fdda8148046310c3eb478b96366ac
+  go_version: go1.16.4 linux/amd64
+  version: v0.12.0
 api_directory_checksum: c1d144a18336326f141e97e6800b47f64ed992cc
 api_version: v1alpha1
-aws_sdk_go_version: 1.38.60
+aws_sdk_go_version: v1.38.47
 generator_config_info:
   file_checksum: 3d4ab94742ecf92212b94a5e47bdda8258589718
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-07-21 20:07:33.392511606 +0000 UTC
+  timestamp: 2021-08-20 14:20:10.007364776 +0000 UTC

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -22,6 +22,7 @@ import (
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	ackrtwebhook "github.com/aws-controllers-k8s/runtime/pkg/webhook"
+	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -38,10 +39,11 @@ import (
 )
 
 var (
-	awsServiceAPIGroup = "dynamodb.services.k8s.aws"
-	awsServiceAlias    = "dynamodb"
-	scheme             = runtime.NewScheme()
-	setupLog           = ctrlrt.Log.WithName("setup")
+	awsServiceAPIGroup    = "dynamodb.services.k8s.aws"
+	awsServiceAlias       = "dynamodb"
+	awsServiceEndpointsID = svcsdk.EndpointsID
+	scheme                = runtime.NewScheme()
+	setupLog              = ctrlrt.Log.WithName("setup")
 )
 
 func init() {
@@ -98,7 +100,7 @@ func main() {
 		"aws.service", awsServiceAlias,
 	)
 	sc := ackrt.NewServiceController(
-		awsServiceAlias, awsServiceAPIGroup,
+		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
 		ackrt.VersionInfo{}, // TODO: populate version info
 	).WithLogger(
 		ctrlrt.Log,

--- a/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: backups.dynamodb.services.k8s.aws
 spec:

--- a/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: globaltables.dynamodb.services.k8s.aws
 spec:

--- a/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
+++ b/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: tables.dynamodb.services.k8s.aws
 spec:

--- a/config/overlays/namespaced/kustomization.yaml
+++ b/config/overlays/namespaced/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- ../../default
+patches:
+- path: role.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: ack-dynamodb-controller
+- path: role-binding.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: ack-dynamodb-controller-rolebinding

--- a/config/overlays/namespaced/role-binding.json
+++ b/config/overlays/namespaced/role-binding.json
@@ -1,0 +1,3 @@
+[{"op": "replace", "path": "/kind", "value": "RoleBinding"},
+{"op": "add", "path": "/metadata/namespace", "value":  "ack-system"},
+{"op": "replace", "path": "/roleRef/kind", "value": "Role"}]

--- a/config/overlays/namespaced/role.json
+++ b/config/overlays/namespaced/role.json
@@ -1,0 +1,2 @@
+[{"op": "replace", "path": "/kind", "value": "Role"},
+{"op": "add", "path": "/metadata/namespace", "value": "ack-system"}]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/dynamodb-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.7.1
+	github.com/aws-controllers-k8s/runtime v0.12.0
 	github.com/aws/aws-sdk-go v1.38.47
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,9 +23,9 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.7.1 h1:iA7x1EBVRffg9aI7vhshWXLYkrd0ySw0qDmGG/10FFg=
-github.com/aws-controllers-k8s/runtime v0.7.1/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws-controllers-k8s/runtime v0.12.0 h1:G/lCEozh4Brsv1Ojqyl9D/whpq/YvcFtDZBWXf6YIgI=
+github.com/aws-controllers-k8s/runtime v0.12.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.47 h1:yWOz6zlDCiY3zvebYOZrI1LqCq6zWPWC5Cfe+mBcPos=
 github.com/aws/aws-sdk-go v1.38.47/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/backup/delta.go
+++ b/pkg/resource/backup/delta.go
@@ -16,7 +16,14 @@
 package backup
 
 import (
+	"reflect"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &reflect.Method{}
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two

--- a/pkg/resource/backup/descriptor.go
+++ b/pkg/resource/backup/descriptor.go
@@ -70,16 +70,6 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
 	return newResourceDelta(a.(*resource), b.(*resource))
 }
 
-// UpdateCRStatus accepts an AWSResource object and changes the Status
-// sub-object of the AWSResource's Kubernetes custom resource (CR) and
-// returns whether any changes were made
-func (d *resourceDescriptor) UpdateCRStatus(
-	res acktypes.AWSResource,
-) (bool, error) {
-	updated := true
-	return updated, nil
-}
-
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a

--- a/pkg/resource/backup/manager.go
+++ b/pkg/resource/backup/manager.go
@@ -18,12 +18,16 @@ package backup
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
@@ -35,6 +39,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=backups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=backups/status,verbs=get;update;patch
+
+var lateInitializeFieldNames = []string{}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -167,6 +173,63 @@ func (rm *resourceManager) ARNFromName(name string) string {
 		rm.awsAccountID,
 		name,
 	)
+}
+
+// LateInitialize returns an acktypes.AWSResource after setting the late initialized
+// fields from the readOne call. This method will initialize the optional fields
+// which were not provided by the k8s user but were defaulted by the AWS service.
+// If there are no such fields to be initialized, the returned object is similar to
+// object passed in the parameter.
+func (rm *resourceManager) LateInitialize(
+	ctx context.Context,
+	latest acktypes.AWSResource,
+) (acktypes.AWSResource, error) {
+	rlog := ackrtlog.FromContext(ctx)
+	// If there are no fields to late initialize, do nothing
+	if len(lateInitializeFieldNames) == 0 {
+		rlog.Debug("no late initialization required.")
+		return latest, nil
+	}
+	lateInitConditionReason := ""
+	lateInitConditionMessage := ""
+	observed, err := rm.ReadOne(ctx, latest)
+	if err != nil {
+		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
+		lateInitConditionReason = "Late Initialization Failure"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, err
+	}
+	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
+	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	if incompleteInitialization {
+		// Add the condition with LateInitialized=False
+		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
+		lateInitConditionReason = "Delayed Late Initialization"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+	}
+	// Set LateIntialized condition to True
+	lateInitConditionMessage = "Late initialization successful"
+	lateInitConditionReason = "Late initialization successful"
+	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return latest, nil
+}
+
+// incompleteLateInitialization return true if there are fields which were supposed to be
+// late initialized but are not. If all the fields are late initialized, false is returned
+func (rm *resourceManager) incompleteLateInitialization(
+	latest acktypes.AWSResource,
+) bool {
+	return false
+}
+
+// lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
+// resource and returns 'latest' resource
+func (rm *resourceManager) lateInitializeFromReadOneOutput(
+	observed acktypes.AWSResource,
+	latest acktypes.AWSResource,
+) acktypes.AWSResource {
+	return latest
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/backup/resource.go
+++ b/pkg/resource/backup/resource.go
@@ -84,6 +84,11 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta
 }
 
+// SetStatus will set the Status field for the resource
+func (r *resource) SetStatus(desired acktypes.AWSResource) {
+	r.ko.Status = desired.(*resource).ko.Status
+}
+
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {

--- a/pkg/resource/backup/sdk.go
+++ b/pkg/resource/backup/sdk.go
@@ -190,6 +190,11 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.BackupExpiryDateTime = nil
 	}
+	if resp.BackupDetails.BackupName != nil {
+		ko.Spec.BackupName = resp.BackupDetails.BackupName
+	} else {
+		ko.Spec.BackupName = nil
+	}
 	if resp.BackupDetails.BackupSizeBytes != nil {
 		ko.Status.BackupSizeBytes = resp.BackupDetails.BackupSizeBytes
 	} else {

--- a/pkg/resource/global_table/delta.go
+++ b/pkg/resource/global_table/delta.go
@@ -16,7 +16,14 @@
 package global_table
 
 import (
+	"reflect"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &reflect.Method{}
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two
@@ -38,6 +45,9 @@ func newResourceDelta(
 		if *a.ko.Spec.GlobalTableName != *b.ko.Spec.GlobalTableName {
 			delta.Add("Spec.GlobalTableName", a.ko.Spec.GlobalTableName, b.ko.Spec.GlobalTableName)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.ReplicationGroup, b.ko.Spec.ReplicationGroup) {
+		delta.Add("Spec.ReplicationGroup", a.ko.Spec.ReplicationGroup, b.ko.Spec.ReplicationGroup)
 	}
 
 	return delta

--- a/pkg/resource/global_table/descriptor.go
+++ b/pkg/resource/global_table/descriptor.go
@@ -70,16 +70,6 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
 	return newResourceDelta(a.(*resource), b.(*resource))
 }
 
-// UpdateCRStatus accepts an AWSResource object and changes the Status
-// sub-object of the AWSResource's Kubernetes custom resource (CR) and
-// returns whether any changes were made
-func (d *resourceDescriptor) UpdateCRStatus(
-	res acktypes.AWSResource,
-) (bool, error) {
-	updated := true
-	return updated, nil
-}
-
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a

--- a/pkg/resource/global_table/manager.go
+++ b/pkg/resource/global_table/manager.go
@@ -18,12 +18,16 @@ package global_table
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
@@ -35,6 +39,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=globaltables,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=globaltables/status,verbs=get;update;patch
+
+var lateInitializeFieldNames = []string{}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -167,6 +173,63 @@ func (rm *resourceManager) ARNFromName(name string) string {
 		rm.awsAccountID,
 		name,
 	)
+}
+
+// LateInitialize returns an acktypes.AWSResource after setting the late initialized
+// fields from the readOne call. This method will initialize the optional fields
+// which were not provided by the k8s user but were defaulted by the AWS service.
+// If there are no such fields to be initialized, the returned object is similar to
+// object passed in the parameter.
+func (rm *resourceManager) LateInitialize(
+	ctx context.Context,
+	latest acktypes.AWSResource,
+) (acktypes.AWSResource, error) {
+	rlog := ackrtlog.FromContext(ctx)
+	// If there are no fields to late initialize, do nothing
+	if len(lateInitializeFieldNames) == 0 {
+		rlog.Debug("no late initialization required.")
+		return latest, nil
+	}
+	lateInitConditionReason := ""
+	lateInitConditionMessage := ""
+	observed, err := rm.ReadOne(ctx, latest)
+	if err != nil {
+		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
+		lateInitConditionReason = "Late Initialization Failure"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, err
+	}
+	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
+	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	if incompleteInitialization {
+		// Add the condition with LateInitialized=False
+		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
+		lateInitConditionReason = "Delayed Late Initialization"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+	}
+	// Set LateIntialized condition to True
+	lateInitConditionMessage = "Late initialization successful"
+	lateInitConditionReason = "Late initialization successful"
+	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return latest, nil
+}
+
+// incompleteLateInitialization return true if there are fields which were supposed to be
+// late initialized but are not. If all the fields are late initialized, false is returned
+func (rm *resourceManager) incompleteLateInitialization(
+	latest acktypes.AWSResource,
+) bool {
+	return false
+}
+
+// lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
+// resource and returns 'latest' resource
+func (rm *resourceManager) lateInitializeFromReadOneOutput(
+	observed acktypes.AWSResource,
+	latest acktypes.AWSResource,
+) acktypes.AWSResource {
+	return latest
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/global_table/resource.go
+++ b/pkg/resource/global_table/resource.go
@@ -84,6 +84,11 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta
 }
 
+// SetStatus will set the Status field for the resource
+func (r *resource) SetStatus(desired acktypes.AWSResource) {
+	r.ko.Status = desired.(*resource).ko.Status
+}
+
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {

--- a/pkg/resource/global_table/sdk.go
+++ b/pkg/resource/global_table/sdk.go
@@ -178,10 +178,28 @@ func (rm *resourceManager) sdkCreate(
 		arn := ackv1alpha1.AWSResourceName(*resp.GlobalTableDescription.GlobalTableArn)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.GlobalTableDescription.GlobalTableName != nil {
+		ko.Spec.GlobalTableName = resp.GlobalTableDescription.GlobalTableName
+	} else {
+		ko.Spec.GlobalTableName = nil
+	}
 	if resp.GlobalTableDescription.GlobalTableStatus != nil {
 		ko.Status.GlobalTableStatus = resp.GlobalTableDescription.GlobalTableStatus
 	} else {
 		ko.Status.GlobalTableStatus = nil
+	}
+	if resp.GlobalTableDescription.ReplicationGroup != nil {
+		f4 := []*svcapitypes.Replica{}
+		for _, f4iter := range resp.GlobalTableDescription.ReplicationGroup {
+			f4elem := &svcapitypes.Replica{}
+			if f4iter.RegionName != nil {
+				f4elem.RegionName = f4iter.RegionName
+			}
+			f4 = append(f4, f4elem)
+		}
+		ko.Spec.ReplicationGroup = f4
+	} else {
+		ko.Spec.ReplicationGroup = nil
 	}
 
 	rm.setStatusDefaults(ko)

--- a/pkg/resource/table/delta.go
+++ b/pkg/resource/table/delta.go
@@ -16,7 +16,14 @@
 package table
 
 import (
+	"reflect"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &reflect.Method{}
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two
@@ -32,6 +39,9 @@ func newResourceDelta(
 		return delta
 	}
 
+	if !reflect.DeepEqual(a.ko.Spec.AttributeDefinitions, b.ko.Spec.AttributeDefinitions) {
+		delta.Add("Spec.AttributeDefinitions", a.ko.Spec.AttributeDefinitions, b.ko.Spec.AttributeDefinitions)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.BillingMode, b.ko.Spec.BillingMode) {
 		delta.Add("Spec.BillingMode", a.ko.Spec.BillingMode, b.ko.Spec.BillingMode)
 	} else if a.ko.Spec.BillingMode != nil && b.ko.Spec.BillingMode != nil {
@@ -39,7 +49,15 @@ func newResourceDelta(
 			delta.Add("Spec.BillingMode", a.ko.Spec.BillingMode, b.ko.Spec.BillingMode)
 		}
 	}
-
+	if !reflect.DeepEqual(a.ko.Spec.GlobalSecondaryIndexes, b.ko.Spec.GlobalSecondaryIndexes) {
+		delta.Add("Spec.GlobalSecondaryIndexes", a.ko.Spec.GlobalSecondaryIndexes, b.ko.Spec.GlobalSecondaryIndexes)
+	}
+	if !reflect.DeepEqual(a.ko.Spec.KeySchema, b.ko.Spec.KeySchema) {
+		delta.Add("Spec.KeySchema", a.ko.Spec.KeySchema, b.ko.Spec.KeySchema)
+	}
+	if !reflect.DeepEqual(a.ko.Spec.LocalSecondaryIndexes, b.ko.Spec.LocalSecondaryIndexes) {
+		delta.Add("Spec.LocalSecondaryIndexes", a.ko.Spec.LocalSecondaryIndexes, b.ko.Spec.LocalSecondaryIndexes)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ProvisionedThroughput, b.ko.Spec.ProvisionedThroughput) {
 		delta.Add("Spec.ProvisionedThroughput", a.ko.Spec.ProvisionedThroughput, b.ko.Spec.ProvisionedThroughput)
 	} else if a.ko.Spec.ProvisionedThroughput != nil && b.ko.Spec.ProvisionedThroughput != nil {
@@ -107,6 +125,9 @@ func newResourceDelta(
 		if *a.ko.Spec.TableName != *b.ko.Spec.TableName {
 			delta.Add("Spec.TableName", a.ko.Spec.TableName, b.ko.Spec.TableName)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/table/descriptor.go
+++ b/pkg/resource/table/descriptor.go
@@ -70,16 +70,6 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
 	return newResourceDelta(a.(*resource), b.(*resource))
 }
 
-// UpdateCRStatus accepts an AWSResource object and changes the Status
-// sub-object of the AWSResource's Kubernetes custom resource (CR) and
-// returns whether any changes were made
-func (d *resourceDescriptor) UpdateCRStatus(
-	res acktypes.AWSResource,
-) (bool, error) {
-	updated := true
-	return updated, nil
-}
-
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a

--- a/pkg/resource/table/manager.go
+++ b/pkg/resource/table/manager.go
@@ -18,12 +18,16 @@ package table
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
@@ -35,6 +39,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=tables,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=tables/status,verbs=get;update;patch
+
+var lateInitializeFieldNames = []string{}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -167,6 +173,63 @@ func (rm *resourceManager) ARNFromName(name string) string {
 		rm.awsAccountID,
 		name,
 	)
+}
+
+// LateInitialize returns an acktypes.AWSResource after setting the late initialized
+// fields from the readOne call. This method will initialize the optional fields
+// which were not provided by the k8s user but were defaulted by the AWS service.
+// If there are no such fields to be initialized, the returned object is similar to
+// object passed in the parameter.
+func (rm *resourceManager) LateInitialize(
+	ctx context.Context,
+	latest acktypes.AWSResource,
+) (acktypes.AWSResource, error) {
+	rlog := ackrtlog.FromContext(ctx)
+	// If there are no fields to late initialize, do nothing
+	if len(lateInitializeFieldNames) == 0 {
+		rlog.Debug("no late initialization required.")
+		return latest, nil
+	}
+	lateInitConditionReason := ""
+	lateInitConditionMessage := ""
+	observed, err := rm.ReadOne(ctx, latest)
+	if err != nil {
+		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
+		lateInitConditionReason = "Late Initialization Failure"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, err
+	}
+	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
+	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	if incompleteInitialization {
+		// Add the condition with LateInitialized=False
+		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
+		lateInitConditionReason = "Delayed Late Initialization"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+	}
+	// Set LateIntialized condition to True
+	lateInitConditionMessage = "Late initialization successful"
+	lateInitConditionReason = "Late initialization successful"
+	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return latest, nil
+}
+
+// incompleteLateInitialization return true if there are fields which were supposed to be
+// late initialized but are not. If all the fields are late initialized, false is returned
+func (rm *resourceManager) incompleteLateInitialization(
+	latest acktypes.AWSResource,
+) bool {
+	return false
+}
+
+// lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
+// resource and returns 'latest' resource
+func (rm *resourceManager) lateInitializeFromReadOneOutput(
+	observed acktypes.AWSResource,
+	latest acktypes.AWSResource,
+) acktypes.AWSResource {
+	return latest
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/table/resource.go
+++ b/pkg/resource/table/resource.go
@@ -84,6 +84,11 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta
 }
 
+// SetStatus will set the Status field for the resource
+func (r *resource) SetStatus(desired acktypes.AWSResource) {
+	r.ko.Status = desired.(*resource).ko.Status
+}
+
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {

--- a/pkg/resource/table/sdk.go
+++ b/pkg/resource/table/sdk.go
@@ -472,6 +472,22 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.ArchivalSummary = nil
 	}
+	if resp.TableDescription.AttributeDefinitions != nil {
+		f1 := []*svcapitypes.AttributeDefinition{}
+		for _, f1iter := range resp.TableDescription.AttributeDefinitions {
+			f1elem := &svcapitypes.AttributeDefinition{}
+			if f1iter.AttributeName != nil {
+				f1elem.AttributeName = f1iter.AttributeName
+			}
+			if f1iter.AttributeType != nil {
+				f1elem.AttributeType = f1iter.AttributeType
+			}
+			f1 = append(f1, f1elem)
+		}
+		ko.Spec.AttributeDefinitions = f1
+	} else {
+		ko.Spec.AttributeDefinitions = nil
+	}
 	if resp.TableDescription.BillingModeSummary != nil {
 		f2 := &svcapitypes.BillingModeSummary{}
 		if resp.TableDescription.BillingModeSummary.BillingMode != nil {
@@ -489,6 +505,59 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.CreationDateTime = nil
 	}
+	if resp.TableDescription.GlobalSecondaryIndexes != nil {
+		f4 := []*svcapitypes.GlobalSecondaryIndex{}
+		for _, f4iter := range resp.TableDescription.GlobalSecondaryIndexes {
+			f4elem := &svcapitypes.GlobalSecondaryIndex{}
+			if f4iter.IndexName != nil {
+				f4elem.IndexName = f4iter.IndexName
+			}
+			if f4iter.KeySchema != nil {
+				f4elemf6 := []*svcapitypes.KeySchemaElement{}
+				for _, f4elemf6iter := range f4iter.KeySchema {
+					f4elemf6elem := &svcapitypes.KeySchemaElement{}
+					if f4elemf6iter.AttributeName != nil {
+						f4elemf6elem.AttributeName = f4elemf6iter.AttributeName
+					}
+					if f4elemf6iter.KeyType != nil {
+						f4elemf6elem.KeyType = f4elemf6iter.KeyType
+					}
+					f4elemf6 = append(f4elemf6, f4elemf6elem)
+				}
+				f4elem.KeySchema = f4elemf6
+			}
+			if f4iter.Projection != nil {
+				f4elemf7 := &svcapitypes.Projection{}
+				if f4iter.Projection.NonKeyAttributes != nil {
+					f4elemf7f0 := []*string{}
+					for _, f4elemf7f0iter := range f4iter.Projection.NonKeyAttributes {
+						var f4elemf7f0elem string
+						f4elemf7f0elem = *f4elemf7f0iter
+						f4elemf7f0 = append(f4elemf7f0, &f4elemf7f0elem)
+					}
+					f4elemf7.NonKeyAttributes = f4elemf7f0
+				}
+				if f4iter.Projection.ProjectionType != nil {
+					f4elemf7.ProjectionType = f4iter.Projection.ProjectionType
+				}
+				f4elem.Projection = f4elemf7
+			}
+			if f4iter.ProvisionedThroughput != nil {
+				f4elemf8 := &svcapitypes.ProvisionedThroughput{}
+				if f4iter.ProvisionedThroughput.ReadCapacityUnits != nil {
+					f4elemf8.ReadCapacityUnits = f4iter.ProvisionedThroughput.ReadCapacityUnits
+				}
+				if f4iter.ProvisionedThroughput.WriteCapacityUnits != nil {
+					f4elemf8.WriteCapacityUnits = f4iter.ProvisionedThroughput.WriteCapacityUnits
+				}
+				f4elem.ProvisionedThroughput = f4elemf8
+			}
+			f4 = append(f4, f4elem)
+		}
+		ko.Spec.GlobalSecondaryIndexes = f4
+	} else {
+		ko.Spec.GlobalSecondaryIndexes = nil
+	}
 	if resp.TableDescription.GlobalTableVersion != nil {
 		ko.Status.GlobalTableVersion = resp.TableDescription.GlobalTableVersion
 	} else {
@@ -499,6 +568,22 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.ItemCount = nil
 	}
+	if resp.TableDescription.KeySchema != nil {
+		f7 := []*svcapitypes.KeySchemaElement{}
+		for _, f7iter := range resp.TableDescription.KeySchema {
+			f7elem := &svcapitypes.KeySchemaElement{}
+			if f7iter.AttributeName != nil {
+				f7elem.AttributeName = f7iter.AttributeName
+			}
+			if f7iter.KeyType != nil {
+				f7elem.KeyType = f7iter.KeyType
+			}
+			f7 = append(f7, f7elem)
+		}
+		ko.Spec.KeySchema = f7
+	} else {
+		ko.Spec.KeySchema = nil
+	}
 	if resp.TableDescription.LatestStreamArn != nil {
 		ko.Status.LatestStreamARN = resp.TableDescription.LatestStreamArn
 	} else {
@@ -508,6 +593,61 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.LatestStreamLabel = resp.TableDescription.LatestStreamLabel
 	} else {
 		ko.Status.LatestStreamLabel = nil
+	}
+	if resp.TableDescription.LocalSecondaryIndexes != nil {
+		f10 := []*svcapitypes.LocalSecondaryIndex{}
+		for _, f10iter := range resp.TableDescription.LocalSecondaryIndexes {
+			f10elem := &svcapitypes.LocalSecondaryIndex{}
+			if f10iter.IndexName != nil {
+				f10elem.IndexName = f10iter.IndexName
+			}
+			if f10iter.KeySchema != nil {
+				f10elemf4 := []*svcapitypes.KeySchemaElement{}
+				for _, f10elemf4iter := range f10iter.KeySchema {
+					f10elemf4elem := &svcapitypes.KeySchemaElement{}
+					if f10elemf4iter.AttributeName != nil {
+						f10elemf4elem.AttributeName = f10elemf4iter.AttributeName
+					}
+					if f10elemf4iter.KeyType != nil {
+						f10elemf4elem.KeyType = f10elemf4iter.KeyType
+					}
+					f10elemf4 = append(f10elemf4, f10elemf4elem)
+				}
+				f10elem.KeySchema = f10elemf4
+			}
+			if f10iter.Projection != nil {
+				f10elemf5 := &svcapitypes.Projection{}
+				if f10iter.Projection.NonKeyAttributes != nil {
+					f10elemf5f0 := []*string{}
+					for _, f10elemf5f0iter := range f10iter.Projection.NonKeyAttributes {
+						var f10elemf5f0elem string
+						f10elemf5f0elem = *f10elemf5f0iter
+						f10elemf5f0 = append(f10elemf5f0, &f10elemf5f0elem)
+					}
+					f10elemf5.NonKeyAttributes = f10elemf5f0
+				}
+				if f10iter.Projection.ProjectionType != nil {
+					f10elemf5.ProjectionType = f10iter.Projection.ProjectionType
+				}
+				f10elem.Projection = f10elemf5
+			}
+			f10 = append(f10, f10elem)
+		}
+		ko.Spec.LocalSecondaryIndexes = f10
+	} else {
+		ko.Spec.LocalSecondaryIndexes = nil
+	}
+	if resp.TableDescription.ProvisionedThroughput != nil {
+		f11 := &svcapitypes.ProvisionedThroughput{}
+		if resp.TableDescription.ProvisionedThroughput.ReadCapacityUnits != nil {
+			f11.ReadCapacityUnits = resp.TableDescription.ProvisionedThroughput.ReadCapacityUnits
+		}
+		if resp.TableDescription.ProvisionedThroughput.WriteCapacityUnits != nil {
+			f11.WriteCapacityUnits = resp.TableDescription.ProvisionedThroughput.WriteCapacityUnits
+		}
+		ko.Spec.ProvisionedThroughput = f11
+	} else {
+		ko.Spec.ProvisionedThroughput = nil
 	}
 	if resp.TableDescription.Replicas != nil {
 		f12 := []*svcapitypes.ReplicaDescription{}
@@ -598,6 +738,18 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.SSEDescription = nil
 	}
+	if resp.TableDescription.StreamSpecification != nil {
+		f15 := &svcapitypes.StreamSpecification{}
+		if resp.TableDescription.StreamSpecification.StreamEnabled != nil {
+			f15.StreamEnabled = resp.TableDescription.StreamSpecification.StreamEnabled
+		}
+		if resp.TableDescription.StreamSpecification.StreamViewType != nil {
+			f15.StreamViewType = resp.TableDescription.StreamSpecification.StreamViewType
+		}
+		ko.Spec.StreamSpecification = f15
+	} else {
+		ko.Spec.StreamSpecification = nil
+	}
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -609,6 +761,11 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.TableID = resp.TableDescription.TableId
 	} else {
 		ko.Status.TableID = nil
+	}
+	if resp.TableDescription.TableName != nil {
+		ko.Spec.TableName = resp.TableDescription.TableName
+	} else {
+		ko.Spec.TableName = nil
 	}
 	if resp.TableDescription.TableSizeBytes != nil {
 		ko.Status.TableSizeBytes = resp.TableDescription.TableSizeBytes
@@ -873,6 +1030,22 @@ func (rm *resourceManager) sdkUpdate(
 	} else {
 		ko.Status.ArchivalSummary = nil
 	}
+	if resp.TableDescription.AttributeDefinitions != nil {
+		f1 := []*svcapitypes.AttributeDefinition{}
+		for _, f1iter := range resp.TableDescription.AttributeDefinitions {
+			f1elem := &svcapitypes.AttributeDefinition{}
+			if f1iter.AttributeName != nil {
+				f1elem.AttributeName = f1iter.AttributeName
+			}
+			if f1iter.AttributeType != nil {
+				f1elem.AttributeType = f1iter.AttributeType
+			}
+			f1 = append(f1, f1elem)
+		}
+		ko.Spec.AttributeDefinitions = f1
+	} else {
+		ko.Spec.AttributeDefinitions = nil
+	}
 	if resp.TableDescription.BillingModeSummary != nil {
 		f2 := &svcapitypes.BillingModeSummary{}
 		if resp.TableDescription.BillingModeSummary.BillingMode != nil {
@@ -890,6 +1063,59 @@ func (rm *resourceManager) sdkUpdate(
 	} else {
 		ko.Status.CreationDateTime = nil
 	}
+	if resp.TableDescription.GlobalSecondaryIndexes != nil {
+		f4 := []*svcapitypes.GlobalSecondaryIndex{}
+		for _, f4iter := range resp.TableDescription.GlobalSecondaryIndexes {
+			f4elem := &svcapitypes.GlobalSecondaryIndex{}
+			if f4iter.IndexName != nil {
+				f4elem.IndexName = f4iter.IndexName
+			}
+			if f4iter.KeySchema != nil {
+				f4elemf6 := []*svcapitypes.KeySchemaElement{}
+				for _, f4elemf6iter := range f4iter.KeySchema {
+					f4elemf6elem := &svcapitypes.KeySchemaElement{}
+					if f4elemf6iter.AttributeName != nil {
+						f4elemf6elem.AttributeName = f4elemf6iter.AttributeName
+					}
+					if f4elemf6iter.KeyType != nil {
+						f4elemf6elem.KeyType = f4elemf6iter.KeyType
+					}
+					f4elemf6 = append(f4elemf6, f4elemf6elem)
+				}
+				f4elem.KeySchema = f4elemf6
+			}
+			if f4iter.Projection != nil {
+				f4elemf7 := &svcapitypes.Projection{}
+				if f4iter.Projection.NonKeyAttributes != nil {
+					f4elemf7f0 := []*string{}
+					for _, f4elemf7f0iter := range f4iter.Projection.NonKeyAttributes {
+						var f4elemf7f0elem string
+						f4elemf7f0elem = *f4elemf7f0iter
+						f4elemf7f0 = append(f4elemf7f0, &f4elemf7f0elem)
+					}
+					f4elemf7.NonKeyAttributes = f4elemf7f0
+				}
+				if f4iter.Projection.ProjectionType != nil {
+					f4elemf7.ProjectionType = f4iter.Projection.ProjectionType
+				}
+				f4elem.Projection = f4elemf7
+			}
+			if f4iter.ProvisionedThroughput != nil {
+				f4elemf8 := &svcapitypes.ProvisionedThroughput{}
+				if f4iter.ProvisionedThroughput.ReadCapacityUnits != nil {
+					f4elemf8.ReadCapacityUnits = f4iter.ProvisionedThroughput.ReadCapacityUnits
+				}
+				if f4iter.ProvisionedThroughput.WriteCapacityUnits != nil {
+					f4elemf8.WriteCapacityUnits = f4iter.ProvisionedThroughput.WriteCapacityUnits
+				}
+				f4elem.ProvisionedThroughput = f4elemf8
+			}
+			f4 = append(f4, f4elem)
+		}
+		ko.Spec.GlobalSecondaryIndexes = f4
+	} else {
+		ko.Spec.GlobalSecondaryIndexes = nil
+	}
 	if resp.TableDescription.GlobalTableVersion != nil {
 		ko.Status.GlobalTableVersion = resp.TableDescription.GlobalTableVersion
 	} else {
@@ -900,6 +1126,22 @@ func (rm *resourceManager) sdkUpdate(
 	} else {
 		ko.Status.ItemCount = nil
 	}
+	if resp.TableDescription.KeySchema != nil {
+		f7 := []*svcapitypes.KeySchemaElement{}
+		for _, f7iter := range resp.TableDescription.KeySchema {
+			f7elem := &svcapitypes.KeySchemaElement{}
+			if f7iter.AttributeName != nil {
+				f7elem.AttributeName = f7iter.AttributeName
+			}
+			if f7iter.KeyType != nil {
+				f7elem.KeyType = f7iter.KeyType
+			}
+			f7 = append(f7, f7elem)
+		}
+		ko.Spec.KeySchema = f7
+	} else {
+		ko.Spec.KeySchema = nil
+	}
 	if resp.TableDescription.LatestStreamArn != nil {
 		ko.Status.LatestStreamARN = resp.TableDescription.LatestStreamArn
 	} else {
@@ -909,6 +1151,61 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.LatestStreamLabel = resp.TableDescription.LatestStreamLabel
 	} else {
 		ko.Status.LatestStreamLabel = nil
+	}
+	if resp.TableDescription.LocalSecondaryIndexes != nil {
+		f10 := []*svcapitypes.LocalSecondaryIndex{}
+		for _, f10iter := range resp.TableDescription.LocalSecondaryIndexes {
+			f10elem := &svcapitypes.LocalSecondaryIndex{}
+			if f10iter.IndexName != nil {
+				f10elem.IndexName = f10iter.IndexName
+			}
+			if f10iter.KeySchema != nil {
+				f10elemf4 := []*svcapitypes.KeySchemaElement{}
+				for _, f10elemf4iter := range f10iter.KeySchema {
+					f10elemf4elem := &svcapitypes.KeySchemaElement{}
+					if f10elemf4iter.AttributeName != nil {
+						f10elemf4elem.AttributeName = f10elemf4iter.AttributeName
+					}
+					if f10elemf4iter.KeyType != nil {
+						f10elemf4elem.KeyType = f10elemf4iter.KeyType
+					}
+					f10elemf4 = append(f10elemf4, f10elemf4elem)
+				}
+				f10elem.KeySchema = f10elemf4
+			}
+			if f10iter.Projection != nil {
+				f10elemf5 := &svcapitypes.Projection{}
+				if f10iter.Projection.NonKeyAttributes != nil {
+					f10elemf5f0 := []*string{}
+					for _, f10elemf5f0iter := range f10iter.Projection.NonKeyAttributes {
+						var f10elemf5f0elem string
+						f10elemf5f0elem = *f10elemf5f0iter
+						f10elemf5f0 = append(f10elemf5f0, &f10elemf5f0elem)
+					}
+					f10elemf5.NonKeyAttributes = f10elemf5f0
+				}
+				if f10iter.Projection.ProjectionType != nil {
+					f10elemf5.ProjectionType = f10iter.Projection.ProjectionType
+				}
+				f10elem.Projection = f10elemf5
+			}
+			f10 = append(f10, f10elem)
+		}
+		ko.Spec.LocalSecondaryIndexes = f10
+	} else {
+		ko.Spec.LocalSecondaryIndexes = nil
+	}
+	if resp.TableDescription.ProvisionedThroughput != nil {
+		f11 := &svcapitypes.ProvisionedThroughput{}
+		if resp.TableDescription.ProvisionedThroughput.ReadCapacityUnits != nil {
+			f11.ReadCapacityUnits = resp.TableDescription.ProvisionedThroughput.ReadCapacityUnits
+		}
+		if resp.TableDescription.ProvisionedThroughput.WriteCapacityUnits != nil {
+			f11.WriteCapacityUnits = resp.TableDescription.ProvisionedThroughput.WriteCapacityUnits
+		}
+		ko.Spec.ProvisionedThroughput = f11
+	} else {
+		ko.Spec.ProvisionedThroughput = nil
 	}
 	if resp.TableDescription.Replicas != nil {
 		f12 := []*svcapitypes.ReplicaDescription{}
@@ -999,6 +1296,18 @@ func (rm *resourceManager) sdkUpdate(
 	} else {
 		ko.Status.SSEDescription = nil
 	}
+	if resp.TableDescription.StreamSpecification != nil {
+		f15 := &svcapitypes.StreamSpecification{}
+		if resp.TableDescription.StreamSpecification.StreamEnabled != nil {
+			f15.StreamEnabled = resp.TableDescription.StreamSpecification.StreamEnabled
+		}
+		if resp.TableDescription.StreamSpecification.StreamViewType != nil {
+			f15.StreamViewType = resp.TableDescription.StreamSpecification.StreamViewType
+		}
+		ko.Spec.StreamSpecification = f15
+	} else {
+		ko.Spec.StreamSpecification = nil
+	}
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -1010,6 +1319,11 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.TableID = resp.TableDescription.TableId
 	} else {
 		ko.Status.TableID = nil
+	}
+	if resp.TableDescription.TableName != nil {
+		ko.Spec.TableName = resp.TableDescription.TableName
+	} else {
+		ko.Spec.TableName = nil
 	}
 	if resp.TableDescription.TableSizeBytes != nil {
 		ko.Status.TableSizeBytes = resp.TableDescription.TableSizeBytes


### PR DESCRIPTION
Issue N/A

Description of changes:
- Brings in ACK runtime 0.12.0

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.