### PR TITLE
update Synced condition for DDB resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-09-12T19:55:03Z"
-  build_hash: 2944c8772f216656d84ee02d392eaca501274c1e
-  go_version: go1.17.5
-  version: v0.20.1
-api_directory_checksum: b9de9af5f2fec85ab3fb5397e7a989da29087a01
+  build_date: "2022-10-14T17:11:08Z"
+  build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
+  go_version: go1.18.1
+  version: v0.20.1-4-g5ee0ac0-dirty
+api_directory_checksum: 69846f77247f7420db696a47cedbb5bd19190601
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 9b6326bdc07bc55fe8d97cc6b3adb1a6e8a15c29
+  file_checksum: cf8320749a4188537376f8cec2b93e5aea7b3b52
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -34,6 +34,12 @@ resources:
         template_path: hooks/table/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/table/sdk_delete_pre_build_request.go.tpl
+    synced:
+      when:
+        - path: Status.TableStatus
+          in:
+            - ACTIVE
+            - ARCHIVED
   GlobalTable:
     exceptions:
       errors:
@@ -44,6 +50,11 @@ resources:
         code: customSetDeleteInput(r, input)
     tags:
       ignore: true
+    synced:
+      when:
+        - path: Status.GlobalTableStatus
+          in:
+            - ACTIVE
   Backup:
     exceptions:
       errors:
@@ -54,3 +65,9 @@ resources:
         template_path: hooks/backup/sdk_read_one_post_set_output.go.tpl
     tags:
       ignore: true
+    synced:
+      when:
+        - path: Status.BackupStatus
+          in:
+            - AVAILABLE
+            - DELETED

--- a/generator.yaml
+++ b/generator.yaml
@@ -34,6 +34,12 @@ resources:
         template_path: hooks/table/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/table/sdk_delete_pre_build_request.go.tpl
+    synced:
+      when:
+        - path: Status.TableStatus
+          in:
+            - ACTIVE
+            - ARCHIVED
   GlobalTable:
     exceptions:
       errors:
@@ -44,6 +50,11 @@ resources:
         code: customSetDeleteInput(r, input)
     tags:
       ignore: true
+    synced:
+      when:
+        - path: Status.GlobalTableStatus
+          in:
+            - ACTIVE
   Backup:
     exceptions:
       errors:
@@ -54,3 +65,9 @@ resources:
         template_path: hooks/backup/sdk_read_one_post_set_output.go.tpl
     tags:
       ignore: true
+    synced:
+      when:
+        - path: Status.BackupStatus
+          in:
+            - AVAILABLE
+            - DELETED

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -4,11 +4,19 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: ack-dynamodb-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{ else }}
 kind: Role
 metadata:
   creationTimestamp: null
   name: ack-dynamodb-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 rules:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -65,6 +65,14 @@
       ],
       "type": "object"
     },
+    "role": {
+      "description": "Role settings",
+      "properties": {
+        "labels": {
+	  "type": "object"
+	}
+      }
+    },
     "metrics": {
       "description": "Metrics settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,10 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+# If "installScope: cluster" then these labels will be applied to ClusterRole
+role:
+ labels: {}
   
 metrics:
   service:

--- a/pkg/resource/backup/manager.go
+++ b/pkg/resource/backup/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.BackupStatus == nil {
+		return false, nil
+	}
+	backupStatusCandidates := []string{"AVAILABLE", "DELETED"}
+	if !ackutil.InStrings(*r.ko.Status.BackupStatus, backupStatusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/global_table/manager.go
+++ b/pkg/resource/global_table/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.GlobalTableStatus == nil {
+		return false, nil
+	}
+	globalTableStatusCandidates := []string{"ACTIVE"}
+	if !ackutil.InStrings(*r.ko.Status.GlobalTableStatus, globalTableStatusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/table/manager.go
+++ b/pkg/resource/table/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.TableStatus == nil {
+		return false, nil
+	}
+	tableStatusCandidates := []string{"ACTIVE", "ARCHIVED"}
+	if !ackutil.InStrings(*r.ko.Status.TableStatus, tableStatusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/test/e2e/condition.py
+++ b/test/e2e/condition.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utility functions to help processing Kubernetes resource conditions"""
+
+import pytest
+
+from acktest.k8s import resource
+
+CONDITION_TYPE_ADOPTED = "ACK.Adopted"
+CONDITION_TYPE_RESOURCE_SYNCED = "ACK.ResourceSynced"
+CONDITION_TYPE_TERMINAL = "ACK.Terminal"
+CONDITION_TYPE_RECOVERABLE = "ACK.Recoverable"
+CONDITION_TYPE_ADVISORY = "ACK.Advisory"
+CONDITION_TYPE_LATE_INITIALIZED = "ACK.LateInitialized"
+CONDITION_TYPE_REFERENCES_RESOLVED = "ACK.ReferencesResolved"
+
+
+def assert_type_status(
+    ref: resource.CustomResourceReference,
+    cond_type_match: str = CONDITION_TYPE_RESOURCE_SYNCED,
+    cond_status_match: bool = True,
+):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource
+        from acktest.k8s import condition
+
+        ref = resource.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        resource.create_custom_resource(ref, resource_data)
+        resource.wait_resource_consumed_by_controller(ref)
+        condition.assert_type_status(
+            ref,
+            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            False)
+
+    Raises:
+        pytest.fail when condition of the specified type is not found or is not
+        in the supplied status.
+    """
+    cond = resource.get_resource_condition(ref, cond_type_match)
+    if cond is None:
+        msg = (f"Failed to find {cond_type_match} condition in "
+               f"resource {ref}")
+        pytest.fail(msg)
+
+    cond_status = cond.get('status', None)
+    if str(cond_status) != str(cond_status_match):
+        msg = (f"Expected {cond_type_match} condition to "
+               f"have status {cond_status_match} but found {cond_status}")
+        pytest.fail(msg)
+
+
+def assert_synced_status(
+    ref: resource.CustomResourceReference,
+    cond_status_match: bool,
+):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource
+        from acktest.k8s import condition
+
+        ref = resource.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        resource.create_custom_resource(ref, resource_data)
+        resource.wait_resource_consumed_by_controller(ref)
+        condition.assert_synced_status(ref, False)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a True status.
+    """
+    assert_type_status(ref, CONDITION_TYPE_RESOURCE_SYNCED, cond_status_match)
+
+
+def assert_synced(ref: resource.CustomResourceReference):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource
+        from acktest.k8s import condition
+
+        ref = resource.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        resource.create_custom_resource(ref, resource_data)
+        resource.wait_resource_consumed_by_controller(ref)
+        condition.assert_synced(ref)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a True status.
+    """
+    return assert_synced_status(ref, True)
+
+
+def assert_not_synced(ref: resource.CustomResourceReference):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is False.
+
+    Usage:
+        from acktest.k8s import resource
+        from acktest.k8s import condition
+
+        ref = resource.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        resource.create_custom_resource(ref, resource_data)
+        resource.wait_resource_consumed_by_controller(ref)
+        condition.assert_not_synced(ref)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a False status.
+    """
+    return assert_synced_status(ref, False)
+

--- a/test/e2e/tests/test_backup.py
+++ b/test/e2e/tests/test_backup.py
@@ -28,6 +28,7 @@ from e2e import (
     wait_for_cr_status,
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import condition
 
 RESOURCE_PLURAL = "backups"
 
@@ -122,6 +123,7 @@ class TestBackup:
             10,
             5,
         )
+        condition.assert_synced(ref)
         
         backupArn = k8s.get_resource_arn(cr)
         # Check DynamoDB Backup exists

--- a/test/e2e/tests/test_global_table.py
+++ b/test/e2e/tests/test_global_table.py
@@ -30,6 +30,7 @@ from e2e import (
     load_dynamodb_resource,
     wait_for_cr_status,
 )
+from e2e import condition
 from e2e.replacement_values import REPLACEMENT_VALUES
 
 RESOURCE_PLURAL = "globaltables"
@@ -129,6 +130,7 @@ class TestGlobalTable:
             10,
             5,
         )
+        condition.assert_synced(ref)
 
         # Check DynamoDB Global Table exists
         exists = self.global_table_exists(dynamodb_client, global_table_name)

--- a/test/e2e/tests/test_table.py
+++ b/test/e2e/tests/test_table.py
@@ -28,6 +28,7 @@ from e2e import (
     get_resource_tags,
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import condition
 from e2e import tag
 
 RESOURCE_PLURAL = "tables"
@@ -94,6 +95,7 @@ class TestTable:
         (ref, res) = forum_table
 
         table_name = res["spec"]["tableName"]
+        condition.assert_synced(ref)
 
         # Check DynamoDB Table exists
         assert self.table_exists(dynamodb_client, table_name)


### PR DESCRIPTION
Adds logic to the resource managers for GlobalTable, Table and
Backup resources to properly understand when
`ACK.ResourceSynced=True` condition should be applied.

Issue aws-controllers-k8s/community#1500

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
