### PR TITLE
release artifacts for `v1.0.1`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-02-10T00:00:47Z"
-  build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
-  go_version: go1.19
-  version: v0.24.2
+  build_date: "2023-02-21T18:45:59Z"
+  build_hash: 9fbf8c4cbf99b2a944ac0e38872b0cd776cc2962
+  go_version: go1.19.1
+  version: v0.24.2-3-g9fbf8c4
 api_directory_checksum: 553eee36730dd0637424a8d9348b37ee90eb594d
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/dynamodb-controller
-  newTag: v0.1.10
+  newTag: v1.0.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: dynamodb-chart
 description: A Helm chart for the ACK service controller for Amazon DynamoDB (DynamoDB)
-version: v0.1.10
-appVersion: v0.1.10
+version: v1.0.1
+appVersion: v1.0.1
 home: https://github.com/aws-controllers-k8s/dynamodb-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/dynamodb-controller:v0.1.10".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/dynamodb-controller:v1.0.1".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/dynamodb-controller
-  tag: v0.1.10
+  tag: v1.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/global_table/sdk.go
+++ b/pkg/resource/global_table/sdk.go
@@ -258,7 +258,7 @@ func (rm *resourceManager) sdkUpdate(
 	defer func() {
 		exit(err)
 	}()
-	input, err := rm.newUpdateRequestPayload(ctx, desired)
+	input, err := rm.newUpdateRequestPayload(ctx, desired, delta)
 	if err != nil {
 		return nil, err
 	}
@@ -319,6 +319,7 @@ func (rm *resourceManager) sdkUpdate(
 func (rm *resourceManager) newUpdateRequestPayload(
 	ctx context.Context,
 	r *resource,
+	delta *ackcompare.Delta,
 ) (*svcsdk.UpdateGlobalTableInput, error) {
 	res := &svcsdk.UpdateGlobalTableInput{}
 


### PR DESCRIPTION
Description of changes:
Regenerates the controller as `v1.0.1` to include the code-generator `v0.24.2` changes. When the `v1.0.0` tag was pushed, there was no release made because of the CD cluster running out of pod resources. Therefore, `v1.0.0` was never released. I pushed out the `v1.0.0` tag again, but in that time the `v0.24.2` code-generator update pushed the version from `v0.1.9` to `v0.1.10` and included those changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
