### PR TITLE
Fix/gsi create and update for provisionedthroughput and nokeyattrs

### DIFF
--- a/pkg/resource/table/hooks.go
+++ b/pkg/resource/table/hooks.go
@@ -113,6 +113,33 @@ func isTableUpdating(r *resource) bool {
 	return dbis == string(v1alpha1.TableStatus_SDK_UPDATING)
 }
 
+// isGSICreating returns true if any GSI is in the process of being created
+//
+// of being deleted
+func isGSICreating(r *resource) bool {
+	return isGSIinStatus(r, v1alpha1.IndexStatus_CREATING)
+}
+
+// isGSIUpdating returns true if any GSI is in the process of being created
+//
+// of being deleted
+func isGSIUpdating(r *resource) bool {
+	return isGSIinStatus(r, v1alpha1.IndexStatus_UPDATING)
+}
+
+func isGSIinStatus(r *resource, indexStatus v1alpha1.IndexStatus) bool {
+	if len(r.ko.Status.GlobalSecondaryIndexesDescriptions) == 0 {
+		return false
+	}
+	gsiDescs := r.ko.Status.GlobalSecondaryIndexesDescriptions
+	for _, gsi := range gsiDescs {
+		if aws.StringValue(gsi.IndexStatus) == string(indexStatus) {
+			return true
+		}
+	}
+	return false
+}
+
 func (rm *resourceManager) customUpdateTable(
 	ctx context.Context,
 	desired *resource,

--- a/pkg/resource/table/hooks.go
+++ b/pkg/resource/table/hooks.go
@@ -200,7 +200,7 @@ func (rm *resourceManager) customUpdateTable(
 			if err := rm.syncTableProvisionedThroughput(ctx, desired); err != nil {
 				return nil, err
 			}
-		case delta.DifferentAt("Spec.GlobalSecondaryIndexes") && delta.DifferentAt("Spec.AttributeDefinitions"):
+		case delta.DifferentAt("Spec.GlobalSecondaryIndexes") || delta.DifferentAt("Spec.AttributeDefinitions"):
 			if err := rm.syncTableGlobalSecondaryIndexes(ctx, latest, desired); err != nil {
 				if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "LimitExceededException" {
 					return nil, requeueWaitGSIReady

--- a/pkg/resource/table/hooks_global_secondary_indexes.go
+++ b/pkg/resource/table/hooks_global_secondary_indexes.go
@@ -233,6 +233,9 @@ func (rm *resourceManager) newUpdateTableGlobalSecondaryIndexUpdatesPayload(
 
 // newSDKProvisionedThroughput builds a new *svcsdk.ProvisionedThroughput
 func newSDKProvisionedThroughput(pt *v1alpha1.ProvisionedThroughput) *svcsdk.ProvisionedThroughput {
+	if pt == nil {
+		return nil
+	}
 	provisionedThroughput := &svcsdk.ProvisionedThroughput{}
 	if pt != nil {
 		if pt.ReadCapacityUnits != nil {
@@ -264,7 +267,7 @@ func newSDKProjection(p *v1alpha1.Projection) *svcsdk.Projection {
 		if p.NonKeyAttributes != nil {
 			projection.NonKeyAttributes = p.NonKeyAttributes
 		} else {
-			projection.NonKeyAttributes = []*string{}
+			projection.NonKeyAttributes = nil
 		}
 	} else {
 		projection.ProjectionType = aws.String("")

--- a/pkg/resource/table/sdk.go
+++ b/pkg/resource/table/sdk.go
@@ -453,6 +453,24 @@ func (rm *resourceManager) sdkFind(
 	if isTableUpdating(&resource{ko}) {
 		return &resource{ko}, requeueWaitWhileUpdating
 	}
+	if isGSICreating(&resource{ko}) {
+		ackcondition.SetSynced(
+			&resource{ko},
+			corev1.ConditionFalse,
+			aws.String("Global Secondary Indexes are being created..."),
+			nil,
+		)
+		return &resource{ko}, requeueWaitWhileCreating
+	}
+	if isGSIUpdating(&resource{ko}) {
+		ackcondition.SetSynced(
+			&resource{ko},
+			corev1.ConditionFalse,
+			aws.String("Global Secondary Indexes are being updated..."),
+			nil,
+		)
+		return &resource{ko}, requeueWaitWhileCreating
+	}
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}

--- a/templates/hooks/table/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/table/sdk_read_one_post_set_output.go.tpl
@@ -59,6 +59,24 @@
 	if isTableUpdating(&resource{ko}) {
 		return &resource{ko}, requeueWaitWhileUpdating
 	}
+	if isGSICreating(&resource{ko}) {
+		ackcondition.SetSynced(
+			&resource{ko},
+			corev1.ConditionFalse,
+			aws.String("Global Secondary Indexes are being created..."),
+			nil,
+		)
+		return &resource{ko}, requeueWaitWhileCreating
+	}
+	if isGSIUpdating(&resource{ko}) {
+		ackcondition.SetSynced(
+			&resource{ko},
+			corev1.ConditionFalse,
+			aws.String("Global Secondary Indexes are being updated..."),
+			nil,
+		)
+		return &resource{ko}, requeueWaitWhileCreating
+	}
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- fix GSI creation happens only when AttributeDefinitions changes
- fix `ProvisionedThrought` validation issue with `PAY_PER_REQUEST` mode  when  creating new GSI
```yaml
2023-04-19T17:31:29.932+0200    ERROR   Reconciler error        {"controller": "table", "controllerGroup": "dynamodb.services.k8s.aws", "controllerKind": "Table", "Table": {"name":"ack-demo-table-provisioned-global-secondary-indexes","namespace":"ack-system"}, "namespace": "ack-system", "name": "ack-demo-table-provisioned-global-secondary-indexes", "reconcileID": "c7354a77-56c4-4c56-b715-f16b59d1926e", "error": "ValidationException: One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST\n\tstatus code: 400, request id: R901I15N84RUVS24D4HVRP6L3JVV4KQNSO5AEMVJF66Q9ASUAAJG"}

2023-04-19T18:54:54.887+0200    ERROR   Reconciler error        {"controller": "table", "controllerGroup": "dynamodb.services.k8s.aws", "controllerKind": "Table", "Table": {"name":"ack-demo-table-provisioned-global-secondary-indexes","namespace":"ack-system"}, "namespace": "ack-system", "name": "ack-demo-table-provisioned-global-secondary-indexes", "reconcileID": "223f9f39-f2cc-460c-ad78-56fce55b4bf3", "error": "ValidationException: One or more parameter values were invalid: ProvisionedThroughput should not be specified for index: id-index when BillingMode is PAY_PER_REQUEST\n\tstatus code: 400, request id: JO5OGQR8IN74JJ2C62O43ESU43VV4KQNSO5AEMVJF66Q9ASUAAJG"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
```
- fix  empty `NonKeyAttributes` validation issue
```yaml
    conditions:
    - message: |
        InvalidParameter: 3 validation error(s) found.
        - minimum field size of 1, UpdateTableInput.GlobalSecondaryIndexUpdates[0].Create.Projection.NonKeyAttributes.
        - minimum field value of 1, UpdateTableInput.GlobalSecondaryIndexUpdates[0].Create.ProvisionedThroughput.ReadCapacityUnits.
        - minimum field value of 1, UpdateTableInput.GlobalSecondaryIndexUpdates[0].Create.ProvisionedThroughput.WriteCapacityUnits.
      status: "True"
      type: ACK.Terminal
``` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
