### PR TITLE
release artifacts for release v1.2.4

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-09-14T23:48:07Z"
+  build_date: "2023-11-14T07:51:52Z"
   build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
   go_version: go1.21.0
   version: v0.27.1

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/dynamodb-controller
-  newTag: 1.2.3
+  newTag: 1.2.4

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: dynamodb-chart
 description: A Helm chart for the ACK service controller for Amazon DynamoDB (DynamoDB)
-version: 1.2.3
-appVersion: 1.2.3
+version: 1.2.4
+appVersion: 1.2.4
 home: https://github.com/aws-controllers-k8s/dynamodb-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/dynamodb-controller:1.2.3".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/dynamodb-controller:1.2.4".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/dynamodb-controller
-  tag: 1.2.3
+  tag: 1.2.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
release v1.2.4
- fix GSI update issue when using `PAY_PER_REQUEST` mode
- set GSI capacity default to 1  when  `PROVISIONED` mode 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
