### PR TITLE
Reuse UpdateGlobalTable for both Update and Delete operations

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -7,7 +7,9 @@ ignore:
   - TableDescription.TableClassSummary
 operations:
   UpdateGlobalTable:
-    operation_type: Delete
+    operation_type:
+    - Update
+    - Delete
     resource_name: GlobalTable
   DescribeBackup:
     output_wrapper_field_path: BackupDescription.BackupDetails


### PR DESCRIPTION
It looks like to delete a GlobalTable we need to delete all it's region
replications. Annd with the new code-generator feature, adding support
of assigning the same AWS operation to multiple resources and CRUD
types. We'll have to explicitely set that this operation supports both
update and delete.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
