### PR TITLE
remove getImmutableFieldChanges references

### DIFF
--- a/pkg/resource/table/hooks.go
+++ b/pkg/resource/table/hooks.go
@@ -137,14 +137,6 @@ func (rm *resourceManager) customUpdateTable(
 	exit := rlog.Trace("rm.customUpdateTable")
 	defer func(err error) { exit(err) }(err)
 
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf(
-			"Immutable Spec fields have been modified: %s",
-			strings.Join(immutableFieldChanges, ","),
-		)
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
-
 	if isTableDeleting(latest) {
 		msg := "table is currently being deleted"
 		setSyncedCondition(desired, corev1.ConditionFalse, &msg, nil)


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
