### PR TITLE
chore: Ensure controller understands both ENABLE & ENABLED `contributorInsights`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-04-01T02:35:33Z"
-  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
+  build_date: "2025-04-08T22:25:51Z"
+  build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
   go_version: go1.24.1
-  version: v0.44.0
+  version: v0.44.0-3-g0909e7f
 api_directory_checksum: 2f94829f12ad90f9c36c48823459c161c1670093
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: e7e79c3c7c21273967ca24947fda0f26b344c8f0
+  file_checksum: cc3489b53a45170d339a4de0d7d7ec0aa788955e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -74,6 +74,8 @@ resources:
         from:
           operation: UpdateContributorInsights
           path: ContributorInsightsAction
+        compare: 
+          is_ignored: true
     exceptions:
       errors:
         404:

--- a/generator.yaml
+++ b/generator.yaml
@@ -74,6 +74,8 @@ resources:
         from:
           operation: UpdateContributorInsights
           path: ContributorInsightsAction
+        compare: 
+          is_ignored: true
     exceptions:
       errors:
         404:

--- a/pkg/resource/table/delta.go
+++ b/pkg/resource/table/delta.go
@@ -62,13 +62,6 @@ func newResourceDelta(
 			}
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.ContributorInsights, b.ko.Spec.ContributorInsights) {
-		delta.Add("Spec.ContributorInsights", a.ko.Spec.ContributorInsights, b.ko.Spec.ContributorInsights)
-	} else if a.ko.Spec.ContributorInsights != nil && b.ko.Spec.ContributorInsights != nil {
-		if *a.ko.Spec.ContributorInsights != *b.ko.Spec.ContributorInsights {
-			delta.Add("Spec.ContributorInsights", a.ko.Spec.ContributorInsights, b.ko.Spec.ContributorInsights)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DeletionProtectionEnabled, b.ko.Spec.DeletionProtectionEnabled) {
 		delta.Add("Spec.DeletionProtectionEnabled", a.ko.Spec.DeletionProtectionEnabled, b.ko.Spec.DeletionProtectionEnabled)
 	} else if a.ko.Spec.DeletionProtectionEnabled != nil && b.ko.Spec.DeletionProtectionEnabled != nil {

--- a/pkg/resource/table/hooks.go
+++ b/pkg/resource/table/hooks.go
@@ -615,8 +615,16 @@ func customPreCompare(
 	// This will ensure controller does not act on this field
 	// if user is unaware of it.
 	if a.ko.Spec.ContributorInsights == nil {
-		a.ko.Spec.ContributorInsights = b.ko.Spec.ContributorInsights
+		return
 	}
+	// latestInsight will always be either ENABLED or DISABLED, since we requeue at readOne if its not 
+	// either
+	desiredInsight, _ := ensureContibutorInsight(a)
+	latestInsight, _ := ensureContibutorInsight(b)
+	if desiredInsight != latestInsight {
+		delta.Add("Spec.ContributorInsights", a.ko.Spec.ContributorInsights, b.ko.Spec.ContributorInsights)
+	}
+
 }
 
 // equalAttributeDefinitions return whether two AttributeDefinition arrays are equal or not.
@@ -774,29 +782,32 @@ func (rm *resourceManager) setContributorInsights(
 	if err != nil {
 		return err
 	}
-	
-	// This portion is needed if we want to have a smooth delta comparison
-	// If the name ends in ED (ENABLED, DISABLED) just assign the value
-	endsWithED := false
-	if ko.Spec.ContributorInsights != nil {
-		endsWithED = strings.HasSuffix(*ko.Spec.TableName, "ED")
-	}
-	if endsWithED {
-		ko.Spec.ContributorInsights = aws.String(string(resp.ContributorInsightsStatus))
-		return nil
-	}
-	// if not do the conversion
-	switch resp.ContributorInsightsStatus {
-	case svcsdktypes.ContributorInsightsStatusEnabled:
-		ko.Spec.ContributorInsights = aws.String(string(svcsdktypes.ContributorInsightsActionEnable))
-	case svcsdktypes.ContributorInsightsStatusDisabled:
-		ko.Spec.ContributorInsights = aws.String(string(svcsdktypes.ContributorInsightsActionDisable))
-	default:
-		ko.Spec.ContributorInsights = aws.String(string(resp.ContributorInsightsStatus))
 
+	// Only manage ContributorInsights if it is defined
+	if ko.Spec.ContributorInsights != nil {
+		ko.Spec.ContributorInsights = aws.String(string(resp.ContributorInsightsStatus))
 	}
 
 	return nil
+}
+
+// ensureContibutorInsight ensures the controller understands ENABLE and ENABLED are the same.
+// We choose to return ContributorInsightsAction because that is the enum used to update.
+func ensureContibutorInsight(r *resource) (svcsdktypes.ContributorInsightsAction, error) {
+	insight := svcsdktypes.ContributorInsightsActionDisable
+	if r.ko.Spec.ContributorInsights != nil {
+		// We will allow users to provide values ENABLE, ENABLED, DISABLE, DISABLED
+		switch *r.ko.Spec.ContributorInsights {
+		case string(svcsdktypes.ContributorInsightsActionEnable), string(svcsdktypes.ContributorInsightsStatusEnabled):
+			insight = svcsdktypes.ContributorInsightsActionEnable
+		case string(svcsdktypes.ContributorInsightsActionDisable), string(svcsdktypes.ContributorInsightsStatusDisabled):
+			insight = svcsdktypes.ContributorInsightsActionDisable
+		default:
+			return "", fmt.Errorf("invalid ContributorInsights value: %s", *r.ko.Spec.ContributorInsights)
+		}
+	}
+
+	return insight, nil
 }
 
 func (rm *resourceManager) updateContributorInsights(
@@ -809,17 +820,9 @@ func (rm *resourceManager) updateContributorInsights(
 		exit(err)
 	}()
 
-	insight := svcsdktypes.ContributorInsightsActionDisable
-	if r.ko.Spec.ContributorInsights != nil {
-		// We will allow users to provide values ENABLE, ENABLED, DISABLE, DISABLED
-		switch *r.ko.Spec.ContributorInsights {
-		case string(svcsdktypes.ContributorInsightsActionEnable), string(svcsdktypes.ContributorInsightsStatusEnabled):
-			insight = svcsdktypes.ContributorInsightsActionEnable
-		case string(svcsdktypes.ContributorInsightsActionDisable), string(svcsdktypes.ContributorInsightsStatusDisabled):
-			insight = svcsdktypes.ContributorInsightsActionDisable
-		default:
-			return fmt.Errorf("invalid ContributorInsights value: %s", *r.ko.Spec.ContributorInsights)
-		}
+	insight, err := ensureContibutorInsight(r)
+	if err != nil {
+		return fmt.Errorf("failed preparing contributorInsight: %v", err)
 	}
 
 	_, err = rm.sdkapi.UpdateContributorInsights(

--- a/test/e2e/resources/table_insights.yaml
+++ b/test/e2e/resources/table_insights.yaml
@@ -7,7 +7,7 @@ spec:
   tableName: $TABLE_NAME
   billingMode: PAY_PER_REQUEST
   tableClass: STANDARD
-  contributorInsights: ENABLE
+  contributorInsights: ENABLED
   attributeDefinitions:
     - attributeName: Bill
       attributeType: S

--- a/test/e2e/tests/test_table.py
+++ b/test/e2e/tests/test_table.py
@@ -279,6 +279,8 @@ class TestTable:
         # Patch k8s resource
         k8s.patch_custom_resource(ref, updates)
 
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
         table.wait_until(
             table_name,
             table.ttl_on_attribute_matches("ForumName"),
@@ -480,7 +482,7 @@ class TestTable:
 
         # Check DynamoDB Table exists
         assert self.table_exists(table_name)
-        assert cr['spec']['contributorInsights'] == "ENABLE"
+        assert cr['spec']['contributorInsights'] == "ENABLED"
         assert self.table_insight_status(table_name, "ENABLED")
 
         # Set provisionedThroughput


### PR DESCRIPTION


Description of changes:
These changes allow users to define both ENABLE/DISABLE and ENABLED/DISABLED value for the ContributorInsights field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
