### PR TITLE
fix: change syncTableTags parameter order to avoid panic

### DIFF
--- a/pkg/resource/table/hooks_tags.go
+++ b/pkg/resource/table/hooks_tags.go
@@ -30,14 +30,14 @@ import (
 // to tag GlobalTable resources.
 func (rm *resourceManager) syncTableTags(
 	ctx context.Context,
-	latest *resource,
 	desired *resource,
+	latest *resource,
 ) (err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.syncTableTags")
 	defer exit(err)
 
-	added, removed := computeTagsDelta(latest.ko.Spec.Tags, desired.ko.Spec.Tags)
+	added, removed := computeTagsDelta(desired.ko.Spec.Tags, latest.ko.Spec.Tags)
 
 	// There are no API calls to update an existing tag. To update a tag we will have to first
 	// delete it and then recreate it with the new value.


### PR DESCRIPTION
Issue [#2459#issuecomment-2886623397](https://github.com/aws-controllers-k8s/community/issues/2459#issuecomment-2886623397)

Description of changes:
In syncTableTags, there was an issue with the order/naming of desired vs
latest resource.

Although the function is called using `syncTableTags(desired, latest)`
the function definition had `syncTableTags(latest, desired)`. This
becomes an issue when we try to retrieve the ARN from latest, during
adoption.
Although in the funciton we named the parameter `latest`, this parameter
was treated as the desired resource when computing the tags delta.

During adoption, the Status/ARN of the desired resource is meant to be 
nil, unitl it is later populated. Hence our need to use the ARN from 
latest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
