### PR TITLE
chore: move updates from create to sdkUpdate

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-06-10T23:41:29Z"
-  build_hash: e675923dfc54d8b6e09730098c3e3e1056d3c1e9
-  go_version: go1.24.3
-  version: v0.48.0
+  build_date: "2025-07-15T01:30:17Z"
+  build_hash: 4640e4fbac38e133c51fc9a0c2ff49e57b1a4d13
+  go_version: go1.24.4
+  version: v0.48.0-4-g4640e4f
 api_directory_checksum: bcdceff2d7ddf7c98141572260ef2e6cee8bf23f
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/table/hooks.go
+++ b/pkg/resource/table/hooks.go
@@ -471,10 +471,6 @@ func (rm *resourceManager) setResourceAdditionalFields(
 	} else {
 		ko.Spec.ContinuousBackups = pitrSpec
 	}
-
-	if err = rm.setContributorInsights(ctx, ko); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/templates/hooks/table/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/table/sdk_create_post_set_output.go.tpl
@@ -1,11 +1,4 @@
-    if desired.ko.Spec.TimeToLive != nil {
-		if err := rm.syncTTL(ctx, desired, &resource{ko}); err != nil {
-			return nil, err
-		}
-	}
-
-	if desired.ko.Spec.ContributorInsights != nil {
-		if err := rm.updateContributorInsights(ctx, desired); err != nil {
-			return nil, err
-		}
+	// handle in sdkUpdate, to give resource time until it creates
+	if desired.ko.Spec.TimeToLive != nil || desired.ko.Spec.ContributorInsights != nil {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}

--- a/templates/hooks/table/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/table/sdk_read_one_post_set_output.go.tpl
@@ -60,9 +60,13 @@
 	if !canUpdateTableGSIs(&resource{ko}) {
 		return &resource{ko}, requeueWaitGSIReady
 	}
-	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
-		return nil, err
+	if err = rm.setContributorInsights(ctx, ko); err != nil {
+		return &resource{ko}, err
 	}
 	if isTableUpdating(&resource{ko}) || isTableContributorInsightsUpdating(&resource{ko}) {
 		return &resource{ko}, requeueWaitWhileUpdating
+	}
+
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
 	}


### PR DESCRIPTION
Description of changes:
Currently, we attempt to make certain update calls in sdkCreate, right
after we populate the resource from createOutput. These calls usually
fail as the Table may still be in `Creating` status.

Another issue that kept happening was a throttling error during sdkFind
for the DescribeTTL call. With these changes, we will be checking the
Table status and reconciling if needed, and only retrieving TTL when the
table has `available` status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
