### PR TITLE
feat: easy localstack integration

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -51,6 +51,13 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
+{{- if .Values.aws.identity_endpoint_url }}
+        - --aws-identity-endpoint-url
+        - "$(AWS_IDENTITY_ENDPOINT_URL)"
+{{- end }}
+{{- if .Values.aws.allow_unsafe_aws_endpoint_urls }}
+        - --allow-unsafe-aws-endpoint-urls
+{{- end }}
 {{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
 {{- end }}
@@ -109,6 +116,8 @@ spec:
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL
           value: {{ .Values.aws.endpoint_url | quote }}
+        - name: AWS_IDENTITY_ENDPOINT_URL
+          value: {{ .Values.aws.identity_endpoint_url | quote }}
         - name: ACK_WATCH_NAMESPACE
           value: {{ include "ack-dynamodb-controller.watch-namespace" . }}
         - name: ACK_WATCH_SELECTORS

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -171,8 +171,15 @@
         "region": {
           "type": "string"
         },
-        "endpoint": {
+        "endpoint_url": {
           "type": "string"
+        },
+        "identity_endpoint_url": {
+          "type": "string"
+        },
+        "allow_unsafe_aws_endpoint_urls": {
+          "type": "boolean",
+          "default": false
         },
         "credentials": {
           "description": "AWS credentials information",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -90,6 +90,8 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   endpoint_url: ""
+  identity_endpoint_url: ""
+  allow_unsafe_aws_endpoint_urls: false
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Made possible to use this helm chart with [localstack](https://github.com/localstack/localstack/) for easy local development.
In order to run ack with localstack and [kind](https://kind.sigs.k8s.io/) you need to configure ack controller to have the identity_endpoint_url set to sts in localstack and enable the allow_unsafe_aws_endpoint_urls.
Without this PR it is impossible to use the original chart.

The chart now has two new optional parameters that enable this integration locally in kind environment.
The deployment manifest now also have this optional parameters.

So, when applying the new helm chart, you can use this:
```bash
helm upgrade --install --force ack-dynamodb-controller --namespace ack-system --set aws.endpoint_url=http://localhost:4566 --set aws.identity_endpoint_url=http://localhost:4566 --set aws.credentials.secretName=xxx --set aws.allow_unsafe_aws_endpoint_urls=true --create-namespace ack/dynamodb-chart
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
