### PR TITLE
tests: Ready condition rename for dynamodb-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aws-controllers-k8s/kms-controller v1.0.21 h1:ar8gCdl/l7qbXzr48YN5tNq4vJbB5UqnRH7pAIkP3tI=
 github.com/aws-controllers-k8s/kms-controller v1.0.21/go.mod h1:tHFXV8lkrzautPPvQtPUJABPlJ9MXPRj8GB1UublGHQ=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
@@ -88,6 +86,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.52.0 h1:EAFg0Mv9Q88Wn8KiKHqvOMnkCamdk/+tJAOEmofLKpY=
+github.com/gustavodiaz7722/ack-runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/condition.py
+++ b/test/e2e/condition.py
@@ -18,7 +18,7 @@ import pytest
 from acktest.k8s import resource
 
 CONDITION_TYPE_ADOPTED = "ACK.Adopted"
-CONDITION_TYPE_RESOURCE_SYNCED = "ACK.ResourceSynced"
+CONDITION_TYPE_READY = "Ready"
 CONDITION_TYPE_TERMINAL = "ACK.Terminal"
 CONDITION_TYPE_RECOVERABLE = "ACK.Recoverable"
 CONDITION_TYPE_ADVISORY = "ACK.Advisory"
@@ -28,11 +28,11 @@ CONDITION_TYPE_REFERENCES_RESOLVED = "ACK.ReferencesResolved"
 
 def assert_type_status(
     ref: resource.CustomResourceReference,
-    cond_type_match: str = CONDITION_TYPE_RESOURCE_SYNCED,
+    cond_type_match: str = CONDITION_TYPE_READY,
     cond_status_match: bool = True,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource
@@ -46,7 +46,7 @@ def assert_type_status(
         resource.wait_resource_consumed_by_controller(ref)
         condition.assert_type_status(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             False)
 
     Raises:
@@ -71,7 +71,7 @@ def assert_synced_status(
     cond_status_match: bool,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource
@@ -86,15 +86,15 @@ def assert_synced_status(
         condition.assert_synced_status(ref, False)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
-    assert_type_status(ref, CONDITION_TYPE_RESOURCE_SYNCED, cond_status_match)
+    assert_type_status(ref, CONDITION_TYPE_READY, cond_status_match)
 
 
-def assert_synced(ref: resource.CustomResourceReference):
+def assert_ready(ref: resource.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource
@@ -106,18 +106,18 @@ def assert_synced(ref: resource.CustomResourceReference):
         )
         resource.create_custom_resource(ref, resource_data)
         resource.wait_resource_consumed_by_controller(ref)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
     return assert_synced_status(ref, True)
 
 
-def assert_not_synced(ref: resource.CustomResourceReference):
+def assert_not_ready(ref: resource.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is False.
+    Ready and that the Status of this condition is False.
 
     Usage:
         from acktest.k8s import resource
@@ -129,10 +129,10 @@ def assert_not_synced(ref: resource.CustomResourceReference):
         )
         resource.create_custom_resource(ref, resource_data)
         resource.wait_resource_consumed_by_controller(ref)
-        condition.assert_not_synced(ref)
+        condition.assert_not_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a False status.
     """
     return assert_synced_status(ref, False)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@38ce32256cc2552ab54e190cc8a8618e93af9e0c
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@6a9b227e8e7eee387f2cf5dfb27df3b4a95c3fb5

--- a/test/e2e/tests/test_backup.py
+++ b/test/e2e/tests/test_backup.py
@@ -125,7 +125,7 @@ class TestBackup:
             20,
             5,
         )
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
         
         backupArn = k8s.get_resource_arn(cr)
         # Check DynamoDB Backup exists

--- a/test/e2e/tests/test_global_table.py
+++ b/test/e2e/tests/test_global_table.py
@@ -132,7 +132,7 @@ class TestGlobalTable:
             10,
             5,
         )
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         # Check DynamoDB Global Table exists
         exists = self.global_table_exists(dynamodb_client, global_table_name)

--- a/test/e2e/tests/test_table.py
+++ b/test/e2e/tests/test_table.py
@@ -175,7 +175,7 @@ class TestTable:
         (ref, res) = table_lsi
 
         table_name = res["spec"]["tableName"]
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         # Check DynamoDB Table exists
         assert self.table_exists(table_name)
@@ -476,7 +476,7 @@ class TestTable:
         (ref, res) = table_insights
 
         table_name = res["spec"]["tableName"]
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
 
@@ -493,7 +493,7 @@ class TestTable:
         }
         # Patch k8s resource
         k8s.patch_custom_resource(ref, updates)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         cr = k8s.get_resource(ref)
         assert cr['spec']['contributorInsights'] == "DISABLE"
         assert self.table_insight_status(table_name, "DISABLED")

--- a/test/e2e/tests/test_table_replicas.py
+++ b/test/e2e/tests/test_table_replicas.py
@@ -372,25 +372,16 @@ class TestTableReplicas:
         max_wait_seconds = 120
         interval_seconds = 10
         start_time = time.time()
-        terminal_condition_found = False
 
         while time.time() - start_time < max_wait_seconds:
             try:
-                condition.assert_type_status(
-                    ref,
-                    condition.CONDITION_TYPE_TERMINAL,
-                    True)
-
-                terminal_condition_found = True
-                cond = k8s.get_resource_condition(
-                    ref, condition.CONDITION_TYPE_TERMINAL)
-                assert "table must have DynamoDB Streams enabled with StreamViewType set to NEW_AND_OLD_IMAGES" in cond[
-                    "message"]
+                condition.assert_terminal(ref, "table must have DynamoDB Streams enabled with StreamViewType set to NEW_AND_OLD_IMAGES")
                 break
             except:
                 time.sleep(interval_seconds)
 
-        assert terminal_condition_found, "Terminal condition was not set for invalid StreamSpecification"
+        condition.assert_terminal(ref, "table must have DynamoDB Streams enabled with StreamViewType set to NEW_AND_OLD_IMAGES")
+
 
     def test_staged_replicas_and_gsi_updates(self, table_replicas_gsi):
         (ref, cr) = table_replicas_gsi


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.