### PR TITLE
Skip TestGlobalTable test

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-03-11T18:57:01Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
+  build_date: "2026-04-21T18:02:10Z"
+  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  go_version: go1.26.1
+  version: v0.58.0-6-gc55e822
 api_directory_checksum: d2887bf57c4e94a2687e17c41f74c875131c0beb
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/test/e2e/tests/test_global_table.py
+++ b/test/e2e/tests/test_global_table.py
@@ -79,7 +79,7 @@ def dynamodb_table():
         pass
 
 @service_marker
-@pytest.mark.canary
+@pytest.mark.skip(reason="CreateGlobalTable: DynamoDB global tables version 2017.11.29 is not supported")
 class TestGlobalTable:
     
     def get_global_table(self, dynamodb_client, global_table_name: str) -> dict:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
TestGlobalTable cases are failing due to below API error for CreateGlobalTable. Skipping test for now to avoid blockages for unrelated changes.

```
operation error DynamoDB: CreateGlobalTable, https response error StatusCode: 400,  api error ValidationException: One or more parameter values were invalid: DynamoDB global tables version 2017.11.29 is not supported. We recommend using DynamoDB global tables version 2019.11.21, instead of version 2017.11.29 (Legacy).
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
