### PR TITLE
Update e2e test matchers to better tolerate delays in table creation/updates

### DIFF
--- a/test/e2e/table.py
+++ b/test/e2e/table.py
@@ -23,7 +23,7 @@ import pytest
 
 from acktest.aws.identity import get_region
 
-DEFAULT_WAIT_UNTIL_TIMEOUT_SECONDS = 60
+DEFAULT_WAIT_UNTIL_TIMEOUT_SECONDS = 300
 DEFAULT_WAIT_UNTIL_INTERVAL_SECONDS = 5
 
 TableMatchFunc = typing.NewType(
@@ -260,7 +260,10 @@ def wait_until(
     now = datetime.datetime.now()
     timeout = now + datetime.timedelta(seconds=timeout_seconds)
 
-    while not match_fn(get(table_name)):
+    while True:
+        record = get(table_name)
+        if record is not None and match_fn(record):
+            return
         if datetime.datetime.now() >= timeout:
             pytest.fail("failed to match table before timeout")
         time.sleep(interval_seconds)

--- a/test/e2e/tests/test_table_replicas.py
+++ b/test/e2e/tests/test_table_replicas.py
@@ -816,7 +816,7 @@ class TestTableReplicas:
                     }
                 }
             ]),
-            timeout_seconds=REPLICA_WAIT_AFTER_SECONDS*2,
+            timeout_seconds=REPLICA_WAIT_AFTER_SECONDS*3,
             interval_seconds=30,
         )
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Update wait_until to tolerate NotFound returns
- Increase default wait period for wait_until matches

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
