### PR TITLE
chore: remove aws-sdk-go (v1) dependency

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -22,7 +22,6 @@ License version 2.0, we include the full text of the package's License below.
 
 * `github.com/aws-controllers-k8s/kms-controller`
 * `github.com/aws-controllers-k8s/runtime`
-* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
 * `github.com/aws/aws-sdk-go-v2/service/dynamodb`
 * `github.com/aws/smithy-go`
@@ -41,7 +40,6 @@ License Identifier: Apache-2.0
 
 Subdependencies:
 * `github.com/aws-controllers-k8s/runtime`
-* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
 * `github.com/aws/aws-sdk-go-v2/service/kms`
 * `github.com/aws/smithy-go`
@@ -75,20 +73,17 @@ Subdependencies:
 * `github.com/go-openapi/jsonpointer`
 * `github.com/go-openapi/jsonreference`
 * `github.com/go-openapi/swag`
-* `github.com/gogo/protobuf`
-* `github.com/golang/groupcache`
-* `github.com/golang/protobuf`
+* `github.com/google/btree`
 * `github.com/google/gnostic-models`
 * `github.com/google/go-cmp`
-* `github.com/google/gofuzz`
 * `github.com/google/uuid`
-* `github.com/imdario/mergo`
 * `github.com/itchyny/gojq`
 * `github.com/itchyny/timefmt-go`
 * `github.com/jaypipes/envutil`
 * `github.com/josharian/intern`
 * `github.com/json-iterator/go`
 * `github.com/mailru/easyjson`
+* `github.com/micahhausler/aws-iam-policy`
 * `github.com/modern-go/concurrent`
 * `github.com/modern-go/reflect2`
 * `github.com/munnerz/goautoneg`
@@ -98,35 +93,33 @@ Subdependencies:
 * `github.com/prometheus/client_model`
 * `github.com/prometheus/common`
 * `github.com/prometheus/procfs`
-* `github.com/samber/lo`
 * `github.com/x448/float16`
 * `go.uber.org/multierr`
 * `go.uber.org/zap`
-* `golang.org/x/exp`
+* `go.yaml.in/yaml/v2`
+* `go.yaml.in/yaml/v3`
 * `golang.org/x/net`
 * `golang.org/x/oauth2`
+* `golang.org/x/sync`
 * `golang.org/x/sys`
 * `golang.org/x/term`
 * `golang.org/x/text`
 * `golang.org/x/time`
 * `gomodules.xyz/jsonpatch/v2`
 * `google.golang.org/protobuf`
+* `gopkg.in/evanphx/json-patch.v4`
 * `gopkg.in/inf.v0`
-* `gopkg.in/yaml.v2`
 * `gopkg.in/yaml.v3`
 * `k8s.io/apiextensions-apiserver`
 * `k8s.io/klog/v2`
 * `k8s.io/kube-openapi`
 * `k8s.io/utils`
 * `sigs.k8s.io/json`
-* `sigs.k8s.io/structured-merge-diff/v4`
+* `sigs.k8s.io/randfill`
+* `sigs.k8s.io/structured-merge-diff/v6`
 * `sigs.k8s.io/yaml`
 
 #### github.com/aws-controllers-k8s/runtime
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go
 
 License Identifier: Apache-2.0
 
@@ -489,80 +482,9 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### github.com/gogo/protobuf
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2013, The GoGo Authors. All rights reserved.
-
-Protocol Buffers for Go with Gadgets
-
-Go support for Protocol Buffers - Google's data interchange format
-
-Copyright 2010 The Go Authors.  All rights reserved.
-https://github.com/golang/protobuf
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/golang/groupcache
+#### github.com/google/btree
 
 License Identifier: Apache-2.0
-
-#### github.com/golang/protobuf
-
-License Identifier: BSD-3-Clause
-
-Copyright 2010 The Go Authors.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/google/gnostic-models
 
@@ -600,48 +522,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#### github.com/google/gofuzz
-
-License Identifier: Apache-2.0
-
 #### github.com/google/uuid
 
 License Identifier: BSD-3-Clause
 
 Copyright (c) 2009,2014 Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/imdario/mergo
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2013 Dario Castañé. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -787,6 +672,20 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#### github.com/micahhausler/aws-iam-policy
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2023, Micah Hausler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #### github.com/modern-go/concurrent
 
 License Identifier: Apache-2.0
@@ -907,32 +806,6 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### github.com/samber/lo
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2022 Samuel Berthe
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 #### github.com/x448/float16
 
 License Identifier: MIT
@@ -1003,37 +876,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-#### golang.org/x/exp
+#### go.yaml.in/yaml/v2
 
-License Identifier: BSD-3-Clause
+License Identifier: Apache-2.0
 
-Copyright (c) 2009 The Go Authors. All rights reserved.
+#### go.yaml.in/yaml/v3
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+License Identifier: Apache-2.0
 
 #### golang.org/x/net
 
@@ -1068,6 +917,38 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### golang.org/x/oauth2
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#### golang.org/x/sync
 
 License Identifier: BSD-3-Clause
 
@@ -1263,6 +1144,36 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### gopkg.in/evanphx/json-patch.v4
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #### gopkg.in/inf.v0
 
 License Identifier: BSD-3-Clause
@@ -1295,10 +1206,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### gopkg.in/yaml.v2
-
-License Identifier: Apache-2.0
 
 #### gopkg.in/yaml.v3
 
@@ -1563,454 +1470,15 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#### sigs.k8s.io/structured-merge-diff/v4
-
-License Identifier: Apache-2.0
-
-#### sigs.k8s.io/yaml
-
-License Identifier: Apache-2.0
-
-### github.com/aws-controllers-k8s/runtime
-
-License Identifier: Apache-2.0
-
-Subdependencies:
-* `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
-* `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
-* `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
-* `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
-* `github.com/spf13/pflag`
-* `github.com/stretchr/testify`
-* `go.uber.org/zap`
-* `k8s.io/api`
-* `k8s.io/apimachinery`
-* `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
-* `sigs.k8s.io/controller-runtime`
-* `sigs.k8s.io/yaml`
-* `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
-* `github.com/aws/aws-sdk-go-v2/internal/configsources`
-* `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
-* `github.com/aws/aws-sdk-go-v2/internal/ini`
-* `github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding`
-* `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
-* `github.com/aws/aws-sdk-go-v2/service/sso`
-* `github.com/aws/aws-sdk-go-v2/service/ssooidc`
-* `github.com/beorn7/perks`
-* `github.com/cespare/xxhash/v2`
-* `github.com/davecgh/go-spew`
-* `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
-* `github.com/evanphx/json-patch/v5`
-* `github.com/fsnotify/fsnotify`
-* `github.com/fxamacker/cbor/v2`
-* `github.com/go-openapi/jsonpointer`
-* `github.com/go-openapi/jsonreference`
-* `github.com/go-openapi/swag`
-* `github.com/google/btree`
-* `github.com/google/gnostic-models`
-* `github.com/google/uuid`
-* `github.com/itchyny/timefmt-go`
-* `github.com/josharian/intern`
-* `github.com/json-iterator/go`
-* `github.com/mailru/easyjson`
-* `github.com/modern-go/concurrent`
-* `github.com/modern-go/reflect2`
-* `github.com/munnerz/goautoneg`
-* `github.com/pmezard/go-difflib`
-* `github.com/prometheus/client_model`
-* `github.com/prometheus/common`
-* `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
-* `github.com/x448/float16`
-* `go.uber.org/multierr`
-* `go.yaml.in/yaml/v2`
-* `go.yaml.in/yaml/v3`
-* `golang.org/x/net`
-* `golang.org/x/oauth2`
-* `golang.org/x/sync`
-* `golang.org/x/sys`
-* `golang.org/x/term`
-* `golang.org/x/text`
-* `golang.org/x/time`
-* `gomodules.xyz/jsonpatch/v2`
-* `google.golang.org/protobuf`
-* `gopkg.in/evanphx/json-patch.v4`
-* `gopkg.in/inf.v0`
-* `gopkg.in/yaml.v3`
-* `k8s.io/apiextensions-apiserver`
-* `k8s.io/kube-openapi`
-* `sigs.k8s.io/json`
-* `sigs.k8s.io/randfill`
-* `sigs.k8s.io/structured-merge-diff/v6`
-
-#### github.com/aws/aws-sdk-go-v2
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/go-logr/logr
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-#### github.com/micahhausler/aws-iam-policy
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2023, Micah Hausler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-
-
-#### github.com/spf13/pflag
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/stretchr/testify
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-#### k8s.io/api
-
-License Identifier: Apache-2.0
-
-#### k8s.io/apimachinery
-
-License Identifier: Apache-2.0
-
-#### k8s.io/client-go
-
-License Identifier: Apache-2.0
-
-
-
-
-
-#### sigs.k8s.io/controller-runtime
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/google/btree
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/stretchr/objx
-
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-
-
-#### go.yaml.in/yaml/v2
-
-License Identifier: Apache-2.0
-
-#### go.yaml.in/yaml/v3
-
-License Identifier: Apache-2.0
-
-
-
-
-
-#### golang.org/x/sync
-
-License Identifier: BSD-3-Clause
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### gopkg.in/evanphx/json-patch.v4
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
 #### sigs.k8s.io/randfill
 
 License Identifier: Apache-2.0
 
 #### sigs.k8s.io/structured-merge-diff/v6
+
+License Identifier: Apache-2.0
+
+#### sigs.k8s.io/yaml
 
 License Identifier: Apache-2.0
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-28T19:06:35Z"
-  build_hash: 399b047701458765c3dd8e9dd663ce2ef0337c05
-  go_version: go1.26.5
-  version: v0.63.0
+  build_date: "2026-09-09T17:56:08Z"
+  build_hash: 3da9ce283716fa8d0046dc18eeb1a79a9e6fb1a0
+  go_version: go1.27.1
+  version: v0.63.0-8-g3da9ce2
 api_directory_checksum: 2047e8c92a67e93f83b87f33b580268980236b1b
 api_version: v1alpha1
 aws_sdk_go_version: v1.36.0

--- a/apis/v1alpha1/table.go
+++ b/apis/v1alpha1/table.go
@@ -29,12 +29,12 @@ type TableSpec struct {
 	// Controls how you are charged for read and write throughput and how you manage
 	// capacity. This setting can be changed later.
 	//
-	//   - PROVISIONED - We recommend using PROVISIONED for predictable workloads.
-	//     PROVISIONED sets the billing mode to Provisioned capacity mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html).
+	//    * PROVISIONED - We recommend using PROVISIONED for predictable workloads.
+	//    PROVISIONED sets the billing mode to Provisioned capacity mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html).
 	//
-	//   - PAY_PER_REQUEST - We recommend using PAY_PER_REQUEST for unpredictable
-	//     workloads. PAY_PER_REQUEST sets the billing mode to On-demand capacity
-	//     mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html).
+	//    * PAY_PER_REQUEST - We recommend using PAY_PER_REQUEST for unpredictable
+	//    workloads. PAY_PER_REQUEST sets the billing mode to On-demand capacity
+	//    mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html).
 	BillingMode *string `json:"billingMode,omitempty"`
 	// Represents the settings used to enable point in time recovery.
 	ContinuousBackups *PointInTimeRecoverySpecification `json:"continuousBackups,omitempty"`
@@ -46,29 +46,27 @@ type TableSpec struct {
 	// One or more global secondary indexes (the maximum is 20) to be created on
 	// the table. Each global secondary index in the array includes the following:
 	//
-	//   - IndexName - The name of the global secondary index. Must be unique only
-	//     for this table.
+	//    * IndexName - The name of the global secondary index. Must be unique only
+	//    for this table.
 	//
-	//   - KeySchema - Specifies the key schema for the global secondary index.
+	//    * KeySchema - Specifies the key schema for the global secondary index.
 	//
-	//   - Projection - Specifies attributes that are copied (projected) from the
-	//     table into the index. These are in addition to the primary key attributes
-	//     and index key attributes, which are automatically projected. Each attribute
-	//     specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+	//    * Projection - Specifies attributes that are copied (projected) from the
+	//    table into the index. These are in addition to the primary key attributes
+	//    and index key attributes, which are automatically projected. Each attribute
+	//    specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+	//    - Only the index and primary keys are projected into the index. INCLUDE
+	//    - Only the specified table attributes are projected into the index. The
+	//    list of projected attributes is in NonKeyAttributes. ALL - All of the
+	//    table attributes are projected into the index. NonKeyAttributes - A list
+	//    of one or more non-key attribute names that are projected into the secondary
+	//    index. The total count of attributes provided in NonKeyAttributes, summed
+	//    across all of the secondary indexes, must not exceed 100. If you project
+	//    the same attribute into two different indexes, this counts as two distinct
+	//    attributes when determining the total.
 	//
-	//   - Only the index and primary keys are projected into the index. INCLUDE
-	//
-	//   - Only the specified table attributes are projected into the index. The
-	//     list of projected attributes is in NonKeyAttributes. ALL - All of the
-	//     table attributes are projected into the index. NonKeyAttributes - A list
-	//     of one or more non-key attribute names that are projected into the secondary
-	//     index. The total count of attributes provided in NonKeyAttributes, summed
-	//     across all of the secondary indexes, must not exceed 100. If you project
-	//     the same attribute into two different indexes, this counts as two distinct
-	//     attributes when determining the total.
-	//
-	//   - ProvisionedThroughput - The provisioned throughput settings for the
-	//     global secondary index, consisting of read and write capacity units.
+	//    * ProvisionedThroughput - The provisioned throughput settings for the
+	//    global secondary index, consisting of read and write capacity units.
 	GlobalSecondaryIndexes []*GlobalSecondaryIndex `json:"globalSecondaryIndexes,omitempty"`
 	// Specifies the attributes that make up the primary key for a table or an index.
 	// The attributes in KeySchema must also be defined in the AttributeDefinitions
@@ -77,10 +75,10 @@ type TableSpec struct {
 	//
 	// Each KeySchemaElement in the array is composed of:
 	//
-	//   - AttributeName - The name of this key attribute.
+	//    * AttributeName - The name of this key attribute.
 	//
-	//   - KeyType - The role that the key attribute will assume: HASH - partition
-	//     key RANGE - sort key
+	//    * KeyType - The role that the key attribute will assume: HASH - partition
+	//    key RANGE - sort key
 	//
 	// The partition key of an item is also known as its hash attribute. The term
 	// "hash attribute" derives from the DynamoDB usage of an internal hash function
@@ -110,28 +108,25 @@ type TableSpec struct {
 	//
 	// Each local secondary index in the array includes the following:
 	//
-	//   - IndexName - The name of the local secondary index. Must be unique only
-	//     for this table.
+	//    * IndexName - The name of the local secondary index. Must be unique only
+	//    for this table.
 	//
-	//   - KeySchema - Specifies the key schema for the local secondary index.
-	//     The key schema must begin with the same partition key as the table.
+	//    * KeySchema - Specifies the key schema for the local secondary index.
+	//    The key schema must begin with the same partition key as the table.
 	//
-	//   - Projection - Specifies attributes that are copied (projected) from the
-	//     table into the index. These are in addition to the primary key attributes
-	//     and index key attributes, which are automatically projected. Each attribute
-	//     specification is composed of: ProjectionType - One of the following: KEYS_ONLY
-	//
-	//   - Only the index and primary keys are projected into the index. INCLUDE
-	//
-	//   - Only the specified table attributes are projected into the index. The
-	//     list of projected attributes is in NonKeyAttributes. ALL - All of the
-	//     table attributes are projected into the index. NonKeyAttributes - A list
-	//     of one or more non-key attribute names that are projected into the secondary
-	//     index. The total count of attributes provided in NonKeyAttributes, summed
-	//     across all of the secondary indexes, must not exceed 100. If you project
-	//     the same attribute into two different indexes, this counts as two distinct
-	//     attributes when determining the total.
-	//
+	//    * Projection - Specifies attributes that are copied (projected) from the
+	//    table into the index. These are in addition to the primary key attributes
+	//    and index key attributes, which are automatically projected. Each attribute
+	//    specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+	//    - Only the index and primary keys are projected into the index. INCLUDE
+	//    - Only the specified table attributes are projected into the index. The
+	//    list of projected attributes is in NonKeyAttributes. ALL - All of the
+	//    table attributes are projected into the index. NonKeyAttributes - A list
+	//    of one or more non-key attribute names that are projected into the secondary
+	//    index. The total count of attributes provided in NonKeyAttributes, summed
+	//    across all of the secondary indexes, must not exceed 100. If you project
+	//    the same attribute into two different indexes, this counts as two distinct
+	//    attributes when determining the total.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	LocalSecondaryIndexes []*LocalSecondaryIndex `json:"localSecondaryIndexes,omitempty"`
 	// Sets the maximum number of read and write units for the specified table in
@@ -150,13 +145,13 @@ type TableSpec struct {
 	ProvisionedThroughput *ProvisionedThroughput `json:"provisionedThroughput,omitempty"`
 	// An Amazon Web Services resource-based policy document in JSON format.
 	//
-	//   - The maximum size supported for a resource-based policy document is 20
-	//     KB. DynamoDB counts whitespaces when calculating the size of a policy
-	//     against this limit.
+	//    * The maximum size supported for a resource-based policy document is 20
+	//    KB. DynamoDB counts whitespaces when calculating the size of a policy
+	//    against this limit.
 	//
-	//   - Within a resource-based policy, if the action for a DynamoDB service-linked
-	//     role (SLR) to replicate data for a global table is denied, adding or deleting
-	//     a replica will fail with an error.
+	//    * Within a resource-based policy, if the action for a DynamoDB service-linked
+	//    role (SLR) to replicate data for a global table is denied, adding or deleting
+	//    a replica will fail with an error.
 	//
 	// For a full list of all considerations that apply while attaching a resource-based
 	// policy, see Resource-based policy considerations (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html).
@@ -165,17 +160,17 @@ type TableSpec struct {
 	SSESpecification *SSESpecification `json:"sseSpecification,omitempty"`
 	// The settings for DynamoDB Streams on the table. These settings consist of:
 	//
-	//   - StreamEnabled - Indicates whether DynamoDB Streams is to be enabled
-	//     (true) or disabled (false).
+	//    * StreamEnabled - Indicates whether DynamoDB Streams is to be enabled
+	//    (true) or disabled (false).
 	//
-	//   - StreamViewType - When an item in the table is modified, StreamViewType
-	//     determines what information is written to the table's stream. Valid values
-	//     for StreamViewType are: KEYS_ONLY - Only the key attributes of the modified
-	//     item are written to the stream. NEW_IMAGE - The entire item, as it appears
-	//     after it was modified, is written to the stream. OLD_IMAGE - The entire
-	//     item, as it appeared before it was modified, is written to the stream.
-	//     NEW_AND_OLD_IMAGES - Both the new and the old item images of the item
-	//     are written to the stream.
+	//    * StreamViewType - When an item in the table is modified, StreamViewType
+	//    determines what information is written to the table's stream. Valid values
+	//    for StreamViewType are: KEYS_ONLY - Only the key attributes of the modified
+	//    item are written to the stream. NEW_IMAGE - The entire item, as it appears
+	//    after it was modified, is written to the stream. OLD_IMAGE - The entire
+	//    item, as it appeared before it was modified, is written to the stream.
+	//    NEW_AND_OLD_IMAGES - Both the new and the old item images of the item
+	//    are written to the stream.
 	StreamSpecification *StreamSpecification `json:"streamSpecification,omitempty"`
 	// The table class of the new table. Valid values are STANDARD and STANDARD_INFREQUENT_ACCESS.
 	TableClass *string `json:"tableClass,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/aws-controllers-k8s/dynamodb-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/kms-controller v1.0.21
+	github.com/aws-controllers-k8s/kms-controller v1.5.0
 	github.com/aws-controllers-k8s/runtime v0.63.0
-	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.39.8
 	github.com/aws/smithy-go v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/kms-controller v1.0.21 h1:ar8gCdl/l7qbXzr48YN5tNq4vJbB5UqnRH7pAIkP3tI=
-github.com/aws-controllers-k8s/kms-controller v1.0.21/go.mod h1:tHFXV8lkrzautPPvQtPUJABPlJ9MXPRj8GB1UublGHQ=
+github.com/aws-controllers-k8s/kms-controller v1.5.0 h1:VgZbNYW+nHQJF8nr3ZLgHoAC+JDpnygnfVcyz29HHyU=
+github.com/aws-controllers-k8s/kms-controller v1.5.0/go.mod h1:7x7QW+WLFP/JjMlcIP0sHtFd2dDNzpZm56rQvHCFya8=
 github.com/aws-controllers-k8s/runtime v0.63.0 h1:BR8uOwV08AoP5bNS7tlqoLXkSK6E82r7K8fJOuaoVZw=
 github.com/aws-controllers-k8s/runtime v0.63.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
-github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
-github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
 github.com/aws/aws-sdk-go-v2 v1.36.0/go.mod h1:5PMILGVKiW32oDzjj6RU52yrNrDPUHcbZQYr1sM7qmM=
 github.com/aws/aws-sdk-go-v2/config v1.28.6 h1:D89IKtGrs/I3QXOLNTH93NJYtDhm8SYa9Q5CsPShmyo=
@@ -91,8 +89,6 @@ github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921i
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
 github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/helm/crds/dynamodb.services.k8s.aws_tables.yaml
+++ b/helm/crds/dynamodb.services.k8s.aws_tables.yaml
@@ -74,12 +74,12 @@ spec:
                   Controls how you are charged for read and write throughput and how you manage
                   capacity. This setting can be changed later.
 
-                    - PROVISIONED - We recommend using PROVISIONED for predictable workloads.
-                      PROVISIONED sets the billing mode to Provisioned capacity mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html).
+                     * PROVISIONED - We recommend using PROVISIONED for predictable workloads.
+                     PROVISIONED sets the billing mode to Provisioned capacity mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html).
 
-                    - PAY_PER_REQUEST - We recommend using PAY_PER_REQUEST for unpredictable
-                      workloads. PAY_PER_REQUEST sets the billing mode to On-demand capacity
-                      mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html).
+                     * PAY_PER_REQUEST - We recommend using PAY_PER_REQUEST for unpredictable
+                     workloads. PAY_PER_REQUEST sets the billing mode to On-demand capacity
+                     mode (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html).
                 type: string
               continuousBackups:
                 description: Represents the settings used to enable point in time
@@ -104,29 +104,27 @@ spec:
                   One or more global secondary indexes (the maximum is 20) to be created on
                   the table. Each global secondary index in the array includes the following:
 
-                    - IndexName - The name of the global secondary index. Must be unique only
-                      for this table.
+                     * IndexName - The name of the global secondary index. Must be unique only
+                     for this table.
 
-                    - KeySchema - Specifies the key schema for the global secondary index.
+                     * KeySchema - Specifies the key schema for the global secondary index.
 
-                    - Projection - Specifies attributes that are copied (projected) from the
-                      table into the index. These are in addition to the primary key attributes
-                      and index key attributes, which are automatically projected. Each attribute
-                      specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+                     * Projection - Specifies attributes that are copied (projected) from the
+                     table into the index. These are in addition to the primary key attributes
+                     and index key attributes, which are automatically projected. Each attribute
+                     specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+                     - Only the index and primary keys are projected into the index. INCLUDE
+                     - Only the specified table attributes are projected into the index. The
+                     list of projected attributes is in NonKeyAttributes. ALL - All of the
+                     table attributes are projected into the index. NonKeyAttributes - A list
+                     of one or more non-key attribute names that are projected into the secondary
+                     index. The total count of attributes provided in NonKeyAttributes, summed
+                     across all of the secondary indexes, must not exceed 100. If you project
+                     the same attribute into two different indexes, this counts as two distinct
+                     attributes when determining the total.
 
-                    - Only the index and primary keys are projected into the index. INCLUDE
-
-                    - Only the specified table attributes are projected into the index. The
-                      list of projected attributes is in NonKeyAttributes. ALL - All of the
-                      table attributes are projected into the index. NonKeyAttributes - A list
-                      of one or more non-key attribute names that are projected into the secondary
-                      index. The total count of attributes provided in NonKeyAttributes, summed
-                      across all of the secondary indexes, must not exceed 100. If you project
-                      the same attribute into two different indexes, this counts as two distinct
-                      attributes when determining the total.
-
-                    - ProvisionedThroughput - The provisioned throughput settings for the
-                      global secondary index, consisting of read and write capacity units.
+                     * ProvisionedThroughput - The provisioned throughput settings for the
+                     global secondary index, consisting of read and write capacity units.
                 items:
                   description: Represents the properties of a global secondary index.
                   properties:
@@ -206,10 +204,10 @@ spec:
 
                   Each KeySchemaElement in the array is composed of:
 
-                    - AttributeName - The name of this key attribute.
+                     * AttributeName - The name of this key attribute.
 
-                    - KeyType - The role that the key attribute will assume: HASH - partition
-                      key RANGE - sort key
+                     * KeyType - The role that the key attribute will assume: HASH - partition
+                     key RANGE - sort key
 
                   The partition key of an item is also known as its hash attribute. The term
                   "hash attribute" derives from the DynamoDB usage of an internal hash function
@@ -261,27 +259,25 @@ spec:
 
                   Each local secondary index in the array includes the following:
 
-                    - IndexName - The name of the local secondary index. Must be unique only
-                      for this table.
+                     * IndexName - The name of the local secondary index. Must be unique only
+                     for this table.
 
-                    - KeySchema - Specifies the key schema for the local secondary index.
-                      The key schema must begin with the same partition key as the table.
+                     * KeySchema - Specifies the key schema for the local secondary index.
+                     The key schema must begin with the same partition key as the table.
 
-                    - Projection - Specifies attributes that are copied (projected) from the
-                      table into the index. These are in addition to the primary key attributes
-                      and index key attributes, which are automatically projected. Each attribute
-                      specification is composed of: ProjectionType - One of the following: KEYS_ONLY
-
-                    - Only the index and primary keys are projected into the index. INCLUDE
-
-                    - Only the specified table attributes are projected into the index. The
-                      list of projected attributes is in NonKeyAttributes. ALL - All of the
-                      table attributes are projected into the index. NonKeyAttributes - A list
-                      of one or more non-key attribute names that are projected into the secondary
-                      index. The total count of attributes provided in NonKeyAttributes, summed
-                      across all of the secondary indexes, must not exceed 100. If you project
-                      the same attribute into two different indexes, this counts as two distinct
-                      attributes when determining the total.
+                     * Projection - Specifies attributes that are copied (projected) from the
+                     table into the index. These are in addition to the primary key attributes
+                     and index key attributes, which are automatically projected. Each attribute
+                     specification is composed of: ProjectionType - One of the following: KEYS_ONLY
+                     - Only the index and primary keys are projected into the index. INCLUDE
+                     - Only the specified table attributes are projected into the index. The
+                     list of projected attributes is in NonKeyAttributes. ALL - All of the
+                     table attributes are projected into the index. NonKeyAttributes - A list
+                     of one or more non-key attribute names that are projected into the secondary
+                     index. The total count of attributes provided in NonKeyAttributes, summed
+                     across all of the secondary indexes, must not exceed 100. If you project
+                     the same attribute into two different indexes, this counts as two distinct
+                     attributes when determining the total.
                 items:
                   description: Represents the properties of a local secondary index.
                   properties:
@@ -362,13 +358,13 @@ spec:
                 description: |-
                   An Amazon Web Services resource-based policy document in JSON format.
 
-                    - The maximum size supported for a resource-based policy document is 20
-                      KB. DynamoDB counts whitespaces when calculating the size of a policy
-                      against this limit.
+                     * The maximum size supported for a resource-based policy document is 20
+                     KB. DynamoDB counts whitespaces when calculating the size of a policy
+                     against this limit.
 
-                    - Within a resource-based policy, if the action for a DynamoDB service-linked
-                      role (SLR) to replicate data for a global table is denied, adding or deleting
-                      a replica will fail with an error.
+                     * Within a resource-based policy, if the action for a DynamoDB service-linked
+                     role (SLR) to replicate data for a global table is denied, adding or deleting
+                     a replica will fail with an error.
 
                   For a full list of all considerations that apply while attaching a resource-based
                   policy, see Resource-based policy considerations (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html).
@@ -401,17 +397,17 @@ spec:
                 description: |-
                   The settings for DynamoDB Streams on the table. These settings consist of:
 
-                    - StreamEnabled - Indicates whether DynamoDB Streams is to be enabled
-                      (true) or disabled (false).
+                     * StreamEnabled - Indicates whether DynamoDB Streams is to be enabled
+                     (true) or disabled (false).
 
-                    - StreamViewType - When an item in the table is modified, StreamViewType
-                      determines what information is written to the table's stream. Valid values
-                      for StreamViewType are: KEYS_ONLY - Only the key attributes of the modified
-                      item are written to the stream. NEW_IMAGE - The entire item, as it appears
-                      after it was modified, is written to the stream. OLD_IMAGE - The entire
-                      item, as it appeared before it was modified, is written to the stream.
-                      NEW_AND_OLD_IMAGES - Both the new and the old item images of the item
-                      are written to the stream.
+                     * StreamViewType - When an item in the table is modified, StreamViewType
+                     determines what information is written to the table's stream. Valid values
+                     for StreamViewType are: KEYS_ONLY - Only the key attributes of the modified
+                     item are written to the stream. NEW_IMAGE - The entire item, as it appears
+                     after it was modified, is written to the stream. OLD_IMAGE - The entire
+                     item, as it appeared before it was modified, is written to the stream.
+                     NEW_AND_OLD_IMAGES - Both the new and the old item images of the item
+                     are written to the stream.
                 properties:
                   streamEnabled:
                     type: boolean

--- a/pkg/resource/table/hooks_global_secondary_indexes_test.go
+++ b/pkg/resource/table/hooks_global_secondary_indexes_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
 )

--- a/pkg/resource/table/hooks_resource_policy_test.go
+++ b/pkg/resource/table/hooks_resource_policy_test.go
@@ -16,7 +16,7 @@ package table
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws-controllers-k8s/dynamodb-controller/apis/v1alpha1"
 	compare "github.com/aws-controllers-k8s/runtime/pkg/compare"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.63.0"
-	ACKGenerateBuildDate = "2026-08-28T19:06:35Z"
+	ACKGenerateVersion   = "v0.63.0-8-g3da9ce2"
+	ACKGenerateBuildDate = "2026-09-09T17:56:08Z"
 )


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2783

Description of changes:
Migrate the remaining test files from aws-sdk-go to aws-sdk-go-v2/aws (aws.String/aws.Int64 are identical in v2), and bump the referenced controller to a release that dropped aws-sdk-go. aws-sdk-go is now fully absent from go.mod and the module graph.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
