### PR TITLE
Increase timeouts to mitigate test failures due to slow server-side async flows

### DIFF
--- a/test/e2e/tests/test_table.py
+++ b/test/e2e/tests/test_table.py
@@ -34,6 +34,12 @@ RESOURCE_PLURAL = "tables"
 CREATE_WAIT_AFTER_SECONDS = 30
 DELETE_WAIT_AFTER_SECONDS = 15
 MODIFY_WAIT_AFTER_SECONDS = 90
+# Some table mutations (billing-mode switch, on-demand throughput change) are
+# applied asynchronously by DynamoDB and can take well over 90s server-side.
+# These waits previously used the bare MODIFY_WAIT_AFTER_SECONDS (90s), which
+# was too tight and caused intermittent "failed to match table before timeout"
+# flakes; use a dedicated, larger floor for those matcher waits.
+SLOW_MODIFY_WAIT_AFTER_SECONDS = 600
 
 def new_gsi_dict(index_name: str, hash_key: str, read_write_pt: int):
     return {
@@ -538,14 +544,14 @@ class TestTable:
         table.wait_until(
             table_name,
             table.billing_mode_matcher("PROVISIONED"),
-            timeout_seconds=MODIFY_WAIT_AFTER_SECONDS,
+            timeout_seconds=SLOW_MODIFY_WAIT_AFTER_SECONDS,
             interval_seconds=3,
         )
 
         table.wait_until(
             table_name,
             table.provisioned_throughput_matcher(5, 5),
-            timeout_seconds=MODIFY_WAIT_AFTER_SECONDS,
+            timeout_seconds=SLOW_MODIFY_WAIT_AFTER_SECONDS,
             interval_seconds=3,
         )
 
@@ -858,8 +864,15 @@ class TestTable:
         table.wait_until(
             table_name,
             table.gsi_matches([new_gsi_dict("office-per-city", "City", 10), new_gsi_dict("office-per-country", "Country", 5)]),
-            timeout_seconds=MODIFY_WAIT_AFTER_SECONDS*40,
-            interval_seconds=15,
+            # This patch both MODIFIES office-per-city and ADDS office-per-country.
+            # DynamoDB only allows one GSI create/update at a time, so the
+            # controller correctly serializes: it waits out office-per-city's
+            # CREATING phase before issuing the office-per-country create, which
+            # then has its own backfill. End-to-end this occasionally exceeds the
+            # previous 1h window; widen it and poll more responsively so a
+            # convergence isn't missed between polls.
+            timeout_seconds=MODIFY_WAIT_AFTER_SECONDS*60,
+            interval_seconds=10,
         )
 
     def test_multi_updates(self, table_gsi):
@@ -1087,7 +1100,7 @@ class TestTable:
         table.wait_until(
             table_name,
             table.on_demand_throughput_matcher(200, 200),
-            timeout_seconds=MODIFY_WAIT_AFTER_SECONDS,
+            timeout_seconds=SLOW_MODIFY_WAIT_AFTER_SECONDS,
             interval_seconds=3,
         )
 

--- a/test/e2e/tests/test_table_replicas.py
+++ b/test/e2e/tests/test_table_replicas.py
@@ -32,7 +32,11 @@ RESOURCE_PLURAL = "tables"
 CREATE_WAIT_AFTER_SECONDS = 30
 DELETE_WAIT_AFTER_SECONDS = 30
 MODIFY_WAIT_AFTER_SECONDS = 600
-REPLICA_WAIT_AFTER_SECONDS = 600
+# Multi-region replica + GSI operations are serialized server-side by DynamoDB
+# (each GSI must leave CREATING before the next mutation is accepted), so
+# convergence can legitimately exceed 10 minutes under load. The base wait is
+# multiplied (e.g. *2, *3) at individual call sites for the heaviest waits.
+REPLICA_WAIT_AFTER_SECONDS = 900
 
 REPLICA_REGION_1 = "us-east-1"
 REPLICA_REGION_2 = "eu-west-1"
@@ -193,7 +197,16 @@ def table_multiple_replicas_gsis():
         table_name, namespace="default",
     )
     k8s.create_custom_resource(ref, resource_data)
-    cr = k8s.wait_resource_consumed_by_controller(ref)
+    # A table with multiple replicas and GSIs can take several minutes for the
+    # controller to first reconcile, so allow up to 5 minutes for the CR to be
+    # consumed (the acktest default is only ~30s). Fail loudly if it never is,
+    # rather than yielding cr=None and crashing downstream with a TypeError.
+    cr = k8s.wait_resource_consumed_by_controller(
+        ref, wait_periods=30, period_length=10,
+    )
+    assert cr is not None, (
+        f"controller never consumed {table_name} within the wait window"
+    )
 
     table.wait_until(
         table_name,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
A number of e2e tests periodically fail due to the test assertions for asynchronous updates failing to observe the updated value before the polling timeout was reached. Checking the controller logs for these failures the controller was legitimately waiting for the AWS resource to reach a stable state before marking the test CR as synced. This PR attempts to mitigate these failures by providing the test harness more time to observe the final state. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
